### PR TITLE
Namespace Refactor

### DIFF
--- a/DependencyInjection/CommandHandlerCompilerPass.php
+++ b/DependencyInjection/CommandHandlerCompilerPass.php
@@ -1,5 +1,5 @@
 <?php
-namespace Xtrasmal\TacticianBundle\DependencyInjection;
+namespace League\Tactician\Bundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php namespace Xtrasmal\TacticianBundle\DependencyInjection;
+<?php namespace League\Tactician\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -1,4 +1,4 @@
-<?php namespace Xtrasmal\TacticianBundle\DependencyInjection;
+<?php namespace League\Tactician\Bundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;

--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -1,5 +1,5 @@
 <?php
-namespace Xtrasmal\TacticianBundle\Handler;
+namespace League\Tactician\Bundle\Handler;
 
 use League\Tactician\Exception\MissingHandlerException;
 use League\Tactician\Handler\Locator\HandlerLocator;

--- a/Middleware/InvalidCommandException.php
+++ b/Middleware/InvalidCommandException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xtrasmal\TacticianBundle\Middleware;
+namespace League\Tactician\Bundle\Middleware;
 
 use League\Tactician\Exception\Exception;
 use Symfony\Component\Validator\ConstraintViolationListInterface;

--- a/Middleware/ValidatorMiddleware.php
+++ b/Middleware/ValidatorMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xtrasmal\TacticianBundle\Middleware;
+namespace League\Tactician\Bundle\Middleware;
 
 use League\Tactician\Middleware;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TacticianBundle
-[![Build Status](https://travis-ci.org/xtrasmal/TacticianBundle.svg)](https://travis-ci.org/xtrasmal/TacticianBundle)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/xtrasmal/TacticianBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/xtrasmal/TacticianBundle/?branch=master)
+[![Build Status](https://travis-ci.org/thephpleague/tactician-bundle.svg)](https://travis-ci.org/thephpleague/tactician-bundle)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/thephpleague/tactician-bundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/thephpleague/tactician-bundle/?branch=master)
 
 Symfony2 Bundle for the Tactician library
 [https://github.com/thephpleague/tactician/](https://github.com/thephpleague/tactician/)
@@ -10,7 +10,7 @@ If you are looking for a Laravel Provider or want to help: [https://github.com/x
 ## Setup 
 First add this bundle to your composer dependencies:
 
-`> composer require xtrasmal\tactician-bundle`
+`> composer require league\tactician-bundle`
 
 Then register it in your AppKernel.php.
 
@@ -20,7 +20,7 @@ class AppKernel extends Kernel
     public function registerBundles()
     {
         $bundles = array(
-            new Xtrasmal\TacticianBundle\TacticianBundle(),
+            new League\Tactician\Bundle\TacticianBundle(),
             // ...
 ```
 

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -3,7 +3,7 @@ parameters:
 
 services:
     tactician.handler.locator.symfony:
-        class: Xtrasmal\TacticianBundle\Handler\ContainerBasedHandlerLocator
+        class: League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator
         arguments:
             - @service_container
 
@@ -19,7 +19,7 @@ services:
         class: League\Tactician\Plugins\LockingMiddleware
 
     tactician.middleware.validator:
-        class: Xtrasmal\TacticianBundle\Middleware\ValidatorMiddleware
+        class: League\Tactician\Bundle\Middleware\ValidatorMiddleware
         arguments:
             - @?validator
 

--- a/TacticianBundle.php
+++ b/TacticianBundle.php
@@ -1,8 +1,8 @@
-<?php namespace Xtrasmal\TacticianBundle;
+<?php namespace League\Tactician\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Xtrasmal\TacticianBundle\DependencyInjection\CommandHandlerCompilerPass;
-use Xtrasmal\TacticianBundle\DependencyInjection\TacticianExtension;
+use League\Tactician\Bundle\DependencyInjection\CommandHandlerCompilerPass;
+use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TacticianBundle extends Bundle

--- a/Tests/DependencyInjection/CommandHandlerCompilerPassTest.php
+++ b/Tests/DependencyInjection/CommandHandlerCompilerPassTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Xtrasmal\TacticianBundle\Tests\DependencyInjection;
+namespace League\Tactician\Bundle\Tests\DependencyInjection;
 
 use Mockery\MockInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Xtrasmal\TacticianBundle\DependencyInjection\CommandHandlerCompilerPass;
+use League\Tactician\Bundle\DependencyInjection\CommandHandlerCompilerPass;
 
 class CommandHandlerCompilerPassTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace Xtrasmal\TacticianBundle\Tests\DependencyInjection;
+namespace League\Tactician\Bundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
-use Xtrasmal\TacticianBundle\DependencyInjection\Configuration;
+use League\Tactician\Bundle\DependencyInjection\Configuration;
 
 class ConfigurationTest extends AbstractConfigurationTestCase
 {

--- a/Tests/Fake/FakeCommand.php
+++ b/Tests/Fake/FakeCommand.php
@@ -1,5 +1,5 @@
 <?php
-namespace Xtrasmal\TacticianBundle\Tests\Fake;
+namespace League\Tactician\Bundle\Tests\Fake;
 
 /**
  * A mock command used in unit testing this bundle

--- a/Tests/Handler/ContainerBasedHandlerLocatorTest.php
+++ b/Tests/Handler/ContainerBasedHandlerLocatorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Xtrasmal\TacticianBundle\Tests\Handler;
+namespace League\Tactician\Bundle\Tests\Handler;
 
 use Mockery\MockInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Xtrasmal\TacticianBundle\Handler\ContainerBasedHandlerLocator;
+use League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator;
 
 class ContainerBasedHandlerLocatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Middleware/ValidatorMiddlewareTest.php
+++ b/Tests/Middleware/ValidatorMiddlewareTest.php
@@ -1,13 +1,13 @@
 <?php
-namespace Xtrasmal\TacticianBundle\Tests\Middleware;
+namespace League\Tactician\Bundle\Tests\Middleware;
 
 use Mockery\MockInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Xtrasmal\TacticianBundle\Middleware\InvalidCommandException;
-use Xtrasmal\TacticianBundle\Middleware\ValidatorMiddleware;
-use Xtrasmal\TacticianBundle\Tests\Fake\FakeCommand;
+use League\Tactician\Bundle\Middleware\InvalidCommandException;
+use League\Tactician\Bundle\Middleware\ValidatorMiddleware;
+use League\Tactician\Bundle\Tests\Fake\FakeCommand;
 
 class ValidatorMiddlewareTest extends \PHPUnit_Framework_TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "homepage": "http://www.rtuin.nl/"
     },
     {
-      "name" : "Xander Smalbil",
-      "email" : "xander@videofunk.nl"
+        "name" : "Xander Smalbil",
+        "email" : "xander@videofunk.nl"
     },
     {
         "name": "Ross Tuck",
@@ -22,7 +22,8 @@
   ],
   "keywords" : [
     "tactician",
-    "bundle"
+    "bundle",
+    "symfony"
   ],
   "license" : [
     "MIT"
@@ -34,7 +35,7 @@
   },
   "autoload" : {
     "psr-4" : {
-      "Xtrasmal\\TacticianBundle\\" : ""
+      "League\\Tactician\\Bundle\\" : ""
     }
   },
   "extra": {


### PR DESCRIPTION
Moved everything to `League\Tactician\Bundle` namespace.
Adjusted a few other places where old name/namespace/repo were still used.