### PR TITLE
Customizable MethodNameInflector

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,13 +45,16 @@ class Configuration implements ConfigurationInterface
                                     )
                                 ->end()
                             ->end()
-
                         ->end()
 
                     ->end()
                 ->end()
                 ->scalarNode('default_bus')
                     ->defaultValue('default')
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('method_inflector')
+                    ->defaultValue('tactician.handler.method_name_inflector.handle')
                     ->cannotBeEmpty()
                 ->end()
             ->end()

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -6,7 +6,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
-use Symfony\Component\Validator\Constraints\All;
 
 class TacticianExtension extends ConfigurableExtension
 {

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ This middleware is bundled in Tactician, please refer to [the official documenta
 
 While not listed this is the core of Tactician and handles executing commands, it should always be enabled.
 
+## Customizing the MethodNameInflector used by the `tactician.middleware.command_handler` middleware
+
+By default the library uses `HandleInflector` to define the handling method names, which maps to `handle()`.
+
+To use a different inflector you can now pass the service name in the config.
+
+```yml
+tactician:
+    method_inflector: my_inflector.service.id
+```
+
+Tactician offers a list of custom Inflectors, these are all supported.
+
+* `tactician.handler.method_name_inflector.handle`
+* `tactician.handler.method_name_inflector.handle_class_name`
+* `tactician.handler.method_name_inflector.handle_class_name_without_suffix`
+* `tactician.handler.method_name_inflector.invoke`
+
 ## Using the Command Bus 
 Create a service and inject the command bus:
 

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -13,7 +13,7 @@ services:
         arguments:
             - @tactician.handler.command_name_extractor.class_name
             - @tactician.handler.locator.symfony
-            - @tactician.handler.method_name_inflector.handle
+            - ''
 
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware
@@ -29,6 +29,9 @@ services:
 
     tactician.handler.method_name_inflector.handle_class_name:
         class: League\Tactician\Handler\MethodNameInflector\HandleClassNameInflector
+
+    tactician.handler.method_name_inflector.handle_class_name_without_suffix:
+        class: League\Tactician\Handler\MethodNameInflector\HandleClassNameWithoutSuffixInflector
 
     tactician.handler.method_name_inflector.invoke:
         class: League\Tactician\Handler\MethodNameInflector\InvokeInflector

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -13,7 +13,7 @@ services:
         arguments:
             - @tactician.handler.command_name_extractor.class_name
             - @tactician.handler.locator.symfony
-            - ''
+            - @tactician.handler.method_name_inflector.handle
 
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -178,4 +178,29 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             ]
         );
     }
+
+    public function testCustomMethodInflectorCanBeSet()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                'tactician' => [
+                    'method_inflector' => 'some.inflector.service',
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'my_middleware.custom.other_stuff',
+                            ],
+                        ],
+                        'second' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'my_middleware.custom.other_stuff',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
+    }
 }

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+
+namespace League\Tactician\Bundle\Tests\DependencyInjection;
+
+
+use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TacticianExtensionTest extends AbstractExtensionTestCase
+{
+    /**
+     * Return an array of container extensions you need to be registered for each test (usually just the container
+     * extension you are testing.
+     *
+     * @return ExtensionInterface[]
+     */
+    protected function getContainerExtensions()
+    {
+        return [
+            new TacticianExtension()
+        ];
+    }
+
+    protected function getMinimalConfiguration()
+    {
+        return [
+            'commandbus' => [
+                'default' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    public function testCommandBusLoadsAndSetsDefault()
+    {
+        $this->load([
+            'commandbus' => [
+                'bus_1' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ],
+                'bus_2' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ],
+            ],
+            'default_bus' => 'bus_2'
+        ]);
+
+        $this->assertContainerBuilderHasService('tactician.commandbus.bus_1');
+        $this->assertContainerBuilderHasService('tactician.commandbus.bus_2');
+        $this->assertContainerBuilderHasAlias('tactician.commandbus', 'tactician.commandbus.bus_2');
+    }
+
+    public function testCommandBusLoadsAndConfigures()
+    {
+
+        $middlewares = [
+            new Reference('my_middleware.custom.stuff'),
+            new Reference('tactician.middleware.command_handler')
+        ];
+
+        $this->load([
+            'commandbus' => [
+                'bus_1' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ],
+                'bus_2' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ],
+            ],
+            'default_bus' => 'bus_2'
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.commandbus.bus_1', 0, $middlewares);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.commandbus.bus_2', 0, $middlewares);
+    }
+
+    public function testCommandBusLoadingDefault()
+    {
+        $this->load();
+        $this->assertContainerBuilderHasService('tactician.commandbus.default');
+    }
+
+    public function testMethodNameInflectorDefault()
+    {
+        $this->load();
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'tactician.middleware.command_handler',
+            2,
+            new Reference('tactician.handler.method_name_inflector.handle')
+        );
+    }
+
+    public function testMethodNameInflectorNonDefault()
+    {
+        $this->load([
+            'method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name_without_suffix'
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'tactician.middleware.command_handler',
+            2,
+            new Reference('tactician.handler.method_name_inflector.handle_class_name_without_suffix')
+        );
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testMethodNameInflectorThrowsErrorIfNonExistingService()
+    {
+        $this->load([
+            'method_inflector' => 'i.do.not.exist'
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "phpunit/phpunit": "~4.5",
     "mockery/mockery": "0.9.*",
     "scrutinizer/ocular": "~1.1",
-    "matthiasnoback/symfony-config-test": "^0",
+    "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "phpunit/phpunit": "~4.5",
     "mockery/mockery": "0.9.*",
     "scrutinizer/ocular": "~1.1",
-    "matthiasnoback/symfony-config-test": "~1.0"
+    "matthiasnoback/symfony-config-test": "^0",
+    "matthiasnoback/symfony-dependency-injection-test": "^0.7"
   }
 }


### PR DESCRIPTION
Allows the default method name inflector to be changed to the strategy you wish, via configuration.
This also adds some more testing goodness.

It downgrades the config tester, but we can fix that when matthiasnoback/SymfonyDependencyInjectionTest#41 is sorted.