### PR TITLE
Upgraded to Tactician 0.6, added Doctrine by default

### DIFF
--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -23,6 +23,11 @@ services:
         arguments:
             - @?validator
 
+    tactician.middleware.doctrine:
+        class: League\Tactician\Doctrine\ORM\TransactionMiddleware
+        arguments:
+            - @doctrine.orm.entity_manager
+
     # The standard Handler method name inflectors
     tactician.handler.method_name_inflector.handle:
         class: League\Tactician\Handler\MethodNameInflector\HandleInflector

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
   "require" : {
     "php":  ">=5.5",
     "league/tactician": "^0.6",
+    "league/tactician-doctrine": "^0.6",
     "symfony/framework-bundle": "~2.3"
   },
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   ],
   "require" : {
     "php":  ">=5.5",
-    "league/tactician": "^0.5",
+    "league/tactician": "^0.6",
     "symfony/framework-bundle": "~2.3"
   },
   "autoload" : {


### PR DESCRIPTION
Should we change the service name from `tactician.middleware.doctrine` to `tactician.middleware.doctrine_transaction` to be more descriptive?