### PR TITLE
ContainerBasedHandlerLocator: unspecified second argument fix

### DIFF
--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -22,9 +22,9 @@ class ContainerBasedHandlerLocator implements HandlerLocator
 
     /**
      * @param ContainerInterface $container
-     * @param $commandToServiceIdMapping
+     * @param array $commandToServiceIdMapping
      */
-    public function __construct(ContainerInterface $container, $commandToServiceIdMapping)
+    public function __construct(ContainerInterface $container, array $commandToServiceIdMapping = [])
     {
         $this->container = $container;
         $this->commandToServiceId = $commandToServiceIdMapping;


### PR DESCRIPTION
Looks like services registration misses second parameter: https://github.com/thephpleague/tactician-bundle/blob/4e17ae5def48d5e5fae8697a6a75129d286ea56a/Resources/config/services/services.yml#L7

I got missing type error for the second argument. So correctly it should be empty array for default (this PR) or specified in the config.