### PR TITLE
Doctrine tweaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,22 @@ php:
   - 7.0
   - hhvm
 
+env:
+  - ''
+  - 'DOCTRINE="false"'
+
 matrix:
   allow_failures:
     - php: 7.0
   include:
       - php: 5.5
         env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+      - php: 5.5
+        env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"'
 
 before_script:
   - travis_retry composer self-update
+  - if [ "${DOCTRINE}" == "false" ]; then composer remove league/tactician-doctrine --dev --no-update; fi
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
 script:

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -1,5 +1,5 @@
 <?php
-namespace League\Tactician\Bundle\DependencyInjection;
+namespace League\Tactician\Bundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * This compiler pass maps Handler DI tags to specific commands
  */
-class CommandHandlerCompilerPass implements CompilerPassInterface
+class CommandHandlerPass implements CompilerPassInterface
 {
     /**
      * You can modify the container here before it is dumped to PHP code.

--- a/DependencyInjection/Compiler/DoctrineMiddlewarePass.php
+++ b/DependencyInjection/Compiler/DoctrineMiddlewarePass.php
@@ -1,0 +1,40 @@
+<?php
+namespace League\Tactician\Bundle\DependencyInjection\Compiler;
+
+use League\Tactician\Doctrine\ORM\TransactionMiddleware;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass registers doctrine entity manager middleware
+ */
+class DoctrineMiddlewarePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(TransactionMiddleware::class) || !$container->hasParameter('doctrine.entity_managers')) {
+            return;
+        }
+
+        $entityManagers = $container->getParameter('doctrine.entity_managers');
+        if (empty($entityManagers)) {
+            return;
+        }
+
+        foreach ($entityManagers as $name => $serviceId) {
+            $container->setDefinition(
+                sprintf('tactician.middleware.doctrine.%s', $name),
+                new Definition(TransactionMiddleware::class, [ new Reference($serviceId) ])
+            );
+        }
+
+        $defaultEntityManager = $container->getParameter('doctrine.default_entity_manager');
+        $container->setAlias('tactician.middleware.doctrine', sprintf('tactician.middleware.doctrine.%s', $defaultEntityManager));
+    }
+}
+

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -23,11 +23,6 @@ services:
         arguments:
             - @?validator
 
-    tactician.middleware.doctrine:
-        class: League\Tactician\Doctrine\ORM\TransactionMiddleware
-        arguments:
-            - @doctrine.orm.entity_manager
-
     # The standard Handler method name inflectors
     tactician.handler.method_name_inflector.handle:
         class: League\Tactician\Handler\MethodNameInflector\HandleInflector

--- a/TacticianBundle.php
+++ b/TacticianBundle.php
@@ -1,7 +1,7 @@
 <?php namespace League\Tactician\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use League\Tactician\Bundle\DependencyInjection\CommandHandlerCompilerPass;
+use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
 use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -10,7 +10,7 @@ class TacticianBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-        $container->addCompilerPass(new CommandHandlerCompilerPass());
+        $container->addCompilerPass(new CommandHandlerPass());
     }
 
     public function getContainerExtension()

--- a/TacticianBundle.php
+++ b/TacticianBundle.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
+use League\Tactician\Bundle\DependencyInjection\Compiler\DoctrineMiddlewarePass;
 use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -10,6 +11,7 @@ class TacticianBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+        $container->addCompilerPass(new DoctrineMiddlewarePass());
         $container->addCompilerPass(new CommandHandlerPass());
     }
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace League\Tactician\Bundle\Tests\DependencyInjection;
+namespace League\Tactician\Bundle\Tests\DependencyInjection\Compiler;
 
 use Mockery\MockInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use League\Tactician\Bundle\DependencyInjection\CommandHandlerCompilerPass;
+use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
 
-class CommandHandlerCompilerPassTest extends \PHPUnit_Framework_TestCase
+class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -16,7 +16,7 @@ class CommandHandlerCompilerPassTest extends \PHPUnit_Framework_TestCase
     protected $container;
 
     /**
-     * @var CommandHandlerCompilerPass
+     * @var CommandHandlerPass
      */
     protected $compiler;
 
@@ -25,7 +25,7 @@ class CommandHandlerCompilerPassTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
         $this->container = \Mockery::mock(ContainerBuilder::class);
 
-        $this->compiler = new CommandHandlerCompilerPass();
+        $this->compiler = new CommandHandlerPass();
     }
 
     public function testProcess()

--- a/Tests/DependencyInjection/Compiler/DoctrineMiddlewarePassTest.php
+++ b/Tests/DependencyInjection/Compiler/DoctrineMiddlewarePassTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests\DependencyInjection\Compiler;
+
+use League\Tactician\Doctrine\ORM\TransactionMiddleware;
+use Mockery\MockInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use League\Tactician\Bundle\DependencyInjection\Compiler\DoctrineMiddlewarePass;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DoctrineMiddlewarePassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder|MockInterface
+     */
+    protected $container;
+
+    /**
+     * @var DoctrineMiddlewarePass
+     */
+    protected $compiler;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->container = \Mockery::mock(ContainerBuilder::class);
+
+        $this->compiler = new DoctrineMiddlewarePass();
+    }
+
+    public function testProcess()
+    {
+        if (!class_exists(TransactionMiddleware::class)) {
+            $this->markTestSkipped('"league/tactician-doctrine" is not installed');
+        }
+
+        $this->container->shouldReceive('hasParameter')
+            ->with('doctrine.entity_managers')
+            ->once()
+            ->andReturn(true);
+
+        $this->container->shouldReceive('getParameter')
+            ->with('doctrine.entity_managers')
+            ->once()
+            ->andReturn([
+                'default' => 'doctrine.orm.default_entity_manager',
+                'second' => 'doctrine.orm.second_entity_manager',
+            ]);
+
+        $this->container->shouldReceive('getParameter')
+            ->with('doctrine.default_entity_manager')
+            ->once()
+            ->andReturn('default');
+
+        $this->container->shouldReceive('setDefinition')
+            ->andReturnUsing(function($name, Definition $def) {
+                \PHPUnit_Framework_Assert::assertEquals('tactician.middleware.doctrine.default', $name);
+
+                \PHPUnit_Framework_Assert::assertEquals(TransactionMiddleware::class, $def->getClass());
+                \PHPUnit_Framework_Assert::assertCount(1, $def->getArguments());
+                \PHPUnit_Framework_Assert::assertInstanceOf(Reference::class, $def->getArgument(0));
+                \PHPUnit_Framework_Assert::assertEquals('doctrine.orm.default_entity_manager', (string)$def->getArgument(0));
+            })
+            ->once();
+
+        $this->container->shouldReceive('setDefinition')
+            ->andReturnUsing(function($name, Definition $def) {
+                \PHPUnit_Framework_Assert::assertEquals('tactician.middleware.doctrine.second', $name);
+
+                \PHPUnit_Framework_Assert::assertEquals(TransactionMiddleware::class, $def->getClass());
+                \PHPUnit_Framework_Assert::assertCount(1, $def->getArguments());
+                \PHPUnit_Framework_Assert::assertInstanceOf(Reference::class, $def->getArgument(0));
+                \PHPUnit_Framework_Assert::assertEquals('doctrine.orm.second_entity_manager', (string)$def->getArgument(0));
+            })
+            ->once();
+
+        $this->container->shouldReceive('setDefinition')
+            ->with('tactician.middleware.doctrine.second')
+            ->once();
+
+        $this->container->shouldReceive('setAlias')
+            ->once()
+            ->with('tactician.middleware.doctrine', 'tactician.middleware.doctrine.default');
+
+        $this->compiler->process($this->container);
+    }
+
+    public function testDoNotProcessWhenThereAreNoEntityManagers()
+    {
+        if (!class_exists(TransactionMiddleware::class)) {
+            $this->markTestSkipped('"league/tactician-doctrine" is not installed');
+        }
+
+        $this->container->shouldReceive('hasParameter')
+            ->with('doctrine.entity_managers')
+            ->once()
+            ->andReturn(false);
+
+        $this->container->shouldNotReceive('getParameter')
+            ->withAnyArgs();
+
+        $this->container->shouldNotReceive('setDefinition')
+            ->withAnyArgs();
+
+        $this->container->shouldNotReceive('setAlias')
+            ->withAnyArgs();
+
+        $this->compiler->process($this->container);
+    }
+
+    public function testDoNotProcessWhenTacticianDoctrineIsNotInstalled()
+    {
+        if (class_exists(TransactionMiddleware::class)) {
+            $this->markTestSkipped('"league/tactician-doctrine" is installed');
+        }
+
+        $this->container->shouldReceive('hasParameter')
+            ->with('doctrine.entity_managers')
+            ->andReturn(true);
+
+        $this->container->shouldNotReceive('getParameter')
+            ->withAnyArgs();
+
+        $this->container->shouldNotReceive('setDefinition')
+            ->withAnyArgs();
+
+        $this->container->shouldNotReceive('setAlias')
+            ->withAnyArgs();
+
+        $this->compiler->process($this->container);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
   "require" : {
     "php":  ">=5.5",
     "league/tactician": "^0.6",
-    "league/tactician-doctrine": "^0.6",
     "symfony/framework-bundle": "~2.3"
   },
   "autoload" : {
@@ -50,6 +49,8 @@
     "mockery/mockery": "0.9.*",
     "scrutinizer/ocular": "~1.1",
     "matthiasnoback/symfony-config-test": "~1.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^0.7"
+    "matthiasnoback/symfony-dependency-injection-test": "^0.7",
+
+    "league/tactician-doctrine": "^0.6"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   "require-dev": {
     "symfony/validator": "~2.3",
     "phpunit/phpunit": "~4.5",
-    "mockery/mockery": "0.9.*",
+    "mockery/mockery": "~0.9.4",
     "scrutinizer/ocular": "~1.1",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "league/tactician": "^0.6",
     "symfony/framework-bundle": "~2.3"
   },
+  "suggest": {
+    "league/tactician-doctrine": "For doctrine transaction middleware"
+  },
   "autoload" : {
     "psr-4" : {
       "League\\Tactician\\Bundle\\" : ""


### PR DESCRIPTION
This PR removed the `league/tactician-doctrine` dependency so that we can use this bundle without doctrine, but it also adds a `tactician.middleware.doctrine` for each if doctrine is register and `league/tactician-doctrine` is installed.

To support multiple EntityManager the `doctrine.entity_managers` is used and a `TransactionMiddleware` is created for each of them `'tactician.middleware.doctrine.<entity_manager_name>'`. Once there are created we will use `doctrine.default_entity_manager` to set the correct alias for `tactician.middleware.doctrine`.