### PR TITLE
Added Symfony3 compatibility

### DIFF
--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -5,15 +5,15 @@ services:
     tactician.handler.locator.symfony:
         class: League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator
         arguments:
-            - @service_container
+            - "@service_container"
 
     # The standard middleware
     tactician.middleware.command_handler:
         class: League\Tactician\Handler\CommandHandlerMiddleware
         arguments:
-            - @tactician.handler.command_name_extractor.class_name
-            - @tactician.handler.locator.symfony
-            - @tactician.handler.method_name_inflector.handle
+            - "@tactician.handler.command_name_extractor.class_name"
+            - "@tactician.handler.locator.symfony"
+            - "@tactician.handler.method_name_inflector.handle"
 
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware
@@ -21,7 +21,7 @@ services:
     tactician.middleware.validator:
         class: League\Tactician\Bundle\Middleware\ValidatorMiddleware
         arguments:
-            - @?validator
+            - "@?validator"
 
     # The standard Handler method name inflectors
     tactician.handler.method_name_inflector.handle:

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,9 @@
   "require" : {
     "php":  ">=5.5",
     "league/tactician": "^0.6",
-    "symfony/framework-bundle": "~2.3"
+    "symfony/framework-bundle": "^2.3|^3.0"
   },
+  "minimum-stability": "beta",
   "suggest": {
     "league/tactician-doctrine": "For doctrine transaction middleware"
   },


### PR DESCRIPTION
I've checked the bundle's tests against Symfony3 and all it needed to pass was escaping service IDs in YAML configuration (`@` is a YAML, reserved for future use).

Note that it's not a full guarantee that the bundle would work in a Symfony 3 application (maybe the tests miss something), but that's a good start :) .