### PR TITLE
Test against different Symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - "$HOME/.composer/cache"
+
 php:
   - 5.5
   - 5.6
@@ -7,25 +13,32 @@ php:
   - hhvm
 
 env:
-  - ''
-  - 'DOCTRINE="false"'
+  matrix:
+    - DOCTRINE="true"
+    - DOCTRINE="false"
 
 matrix:
   allow_failures:
     - php: 7.0
   include:
-      - php: 5.5
-        env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-      - php: 5.5
-        env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"'
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"
+    - php: 5.6
+      env: SYMFONY_VERSION="2.7.*"
+    - php: 5.6
+      env: SYMFONY_VERSION="2.8.*"
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.*"
 
-before_script:
-  - travis_retry composer self-update
-  - if [ "${DOCTRINE}" == "false" ]; then composer remove league/tactician-doctrine --dev --no-update; fi
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
+before_install:
+  - composer self-update || true
+  - if [ "$DOCTRINE" == "false" ]; then composer remove league/tactician-doctrine --dev --no-update; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
 
-script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+install: composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
-after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+script: phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_script: php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.*"
+      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 before_install:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,6 @@ install: composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
 script: phpunit --coverage-text --coverage-clover=coverage.clover
 
-after_script: php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
     "symfony/validator": "~2.3",
     "phpunit/phpunit": "~4.5",
     "mockery/mockery": "~0.9.4",
-    "scrutinizer/ocular": "~1.1",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
 


### PR DESCRIPTION
This bundle claims Symfony 2.3 - 3.0 support, but it only tests against 2.3 and 2.8. Let's test all supported Symfony versions that didn't reach end of life yet.

Also, this PR updates the config to use the new docker-based Travis environment. This will speed up tests quite a bit and makes it possible to cache directories (e.g. Composer packages).