### PR TITLE
Removed method inflector service check

### DIFF
--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -59,18 +59,11 @@ class TacticianExtension extends ConfigurableExtension
      *
      * @param array $mergedConfig
      * @param ContainerBuilder $container
-     * @throws \Exception
      */
     private function injectMethodNameInflector(array $mergedConfig, ContainerBuilder $container)
     {
         if (! $container->has('tactician.middleware.command_handler')) {
             return;
-        }
-
-        if (! $container->has($mergedConfig['method_inflector'])) {
-            throw new \Exception(
-                'Unable to find requested method_inflector service definition: ' . $mergedConfig['method_inflector']
-            );
         }
 
         $inflectorReference = new Reference($mergedConfig['method_inflector']);

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -121,14 +121,4 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
             new Reference('tactician.handler.method_name_inflector.handle_class_name_without_suffix')
         );
     }
-
-    /**
-     * @expectedException \Exception
-     */
-    public function testMethodNameInflectorThrowsErrorIfNonExistingService()
-    {
-        $this->load([
-            'method_inflector' => 'i.do.not.exist'
-        ]);
-    }
 }


### PR DESCRIPTION
This small PR only removes the method inflector service check (mentioned by @boekkooi in https://github.com/thephpleague/tactician-bundle/issues/3#issuecomment-115632201), so it is possible to define the custom method name inflector. 