### PR TITLE
replaced FrameworkBundle dependency by components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,11 @@
   "require" : {
     "php":  ">=5.5",
     "league/tactician": "^1.0",
-    "symfony/framework-bundle": "^2.3|^3.0"
+    "symfony/config": "^2.3|^3.0",
+    "symfony/dependency-injection": "^2.3|^3.0",
+    "symfony/http-kernel": "^2.3|^3.0",
+    "symfony/validator": "^2.3|^3.0",
+    "symfony/yaml": "^2.3|^3.0"
   },
   "minimum-stability": "beta",
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     "symfony/config": "^2.3|^3.0",
     "symfony/dependency-injection": "^2.3|^3.0",
     "symfony/http-kernel": "^2.3|^3.0",
-    "symfony/validator": "^2.3|^3.0",
     "symfony/yaml": "^2.3|^3.0"
   },
   "minimum-stability": "beta",
   "suggest": {
+    "symfony/validator": "For command validator middleware",
     "league/tactician-doctrine": "For doctrine transaction middleware"
   },
   "autoload" : {
@@ -52,12 +52,12 @@
     }
   },
   "require-dev": {
-    "symfony/validator": "^2.3|^3.0",
     "phpunit/phpunit": "~4.5",
     "mockery/mockery": "~0.9.4",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
 
+    "symfony/validator": "^2.3|^3.0",
     "league/tactician-doctrine": "^1.0"
   }
 }


### PR DESCRIPTION
TacticianBundle was previously marked as depending directly on FrameworkBundle, when it's actually only dependent on some components:

* Config
* DependencyInjection
* HttpKernel
* Validator (1)
* Yaml

Many third party bundles specify `symfony/framework-bundle` as a dependency when it is not necessarily the case: as long as a bundle doesn't use a class from the `Symfony\FrameworkBundle` namespace it doesn't actually rely on it.

For example, have a look at [MonologBundle](https://github.com/symfony/monolog-bundle/blob/08ac8611171df84d6c4b9d28b02e596731890600/composer.json#L18): since it doesn't use any classes from the `Symfony\FrameworkBundle` namespace, it only specifies components in its `composer.json`.

Bundles responsibility is to provide their Dependency Injection configuration for projects using Symfony HttpKernel: they're also useful for projects that don't use the standard full stack framework.

This Pull Request aims at extending TacticianBundle compatibility to these other projects.

> **Note 1**: It looks like the dependency on validator is optional and could be extracted to its own bundle.