### PR TITLE
WIP Allow tagging handlers per bus

### DIFF
--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -1,6 +1,8 @@
 <?php
 namespace League\Tactician\Bundle\DependencyInjection\Compiler;
 
+use League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -91,7 +93,7 @@ class CommandHandlerPass implements CompilerPassInterface
     protected function buildLocatorDefinition(array $handlerMapping)
     {
         return new Definition(
-            'League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator',
+            ContainerBasedHandlerLocator::class,
             [
                 new Reference('service_container'),
                 $handlerMapping,
@@ -108,7 +110,7 @@ class CommandHandlerPass implements CompilerPassInterface
         $config = $container->getExtensionConfig('tactician');
 
         return new Definition(
-            'League\Tactician\Handler\CommandHandlerMiddleware',
+            CommandHandlerMiddleware::class,
             [
                 new Reference('tactician.handler.command_name_extractor.class_name'),
                 new Reference($locatorServiceId),

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -61,6 +61,11 @@ class CommandHandlerPass implements CompilerPassInterface
             );
         }
 
+        $container->setAlias(
+            'tactician.handler.locator.symfony',
+            'tactician.commandbus.'.$defaultBusId.'.handler.locator'
+        );
+
         $handlerLocator->addArgument($defaultMapping);
     }
 

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -31,11 +31,9 @@ class CommandHandlerPass implements CompilerPassInterface
                     throw new \Exception('The tactician.handler tag must always have a command attribute');
                 }
 
-                if (array_key_exists('bus', $attributes)) {
-                    $this->abortIfInvalidBusId($attributes['bus'], $container);
-                }
-
                 $busId = array_key_exists('bus', $attributes) ? $attributes['bus'] : $defaultBusId;
+
+                $this->abortIfInvalidBusId($busId, $container);
 
                 $busIdToHandlerMapping[$busId][$attributes['command']] = $id;
             }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -27,8 +27,6 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $mapping = [];
 
-        $config = $container->getExtensionConfig('tactician');
-
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
 
             foreach ($tags as $attributes) {
@@ -37,9 +35,7 @@ class CommandHandlerPass implements CompilerPassInterface
                 }
 
                 if (isset($attributes['bus'])) {
-                    if (!array_key_exists($attributes['bus'], $config['commandbus'])) {
-                        throw new \Exception('Invalid bus id "'.$attributes['bus'].'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
-                    }
+                    $this->abortIfInvalidBusId($id, $container);
                 }
 
                 $mapping[$attributes['command']] = $id;
@@ -47,6 +43,15 @@ class CommandHandlerPass implements CompilerPassInterface
         }
 
         $handlerLocator->addArgument($mapping);
+    }
+
+    protected function abortIfInvalidBusId($id, ContainerBuilder $container)
+    {
+        $config = $container->getExtensionConfig('tactician');
+
+        if (!array_key_exists($id, $config['commandbus'])) {
+            throw new \Exception('Invalid bus id "'.$id.'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
+        }
     }
 
 }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -54,6 +54,11 @@ class CommandHandlerPass implements CompilerPassInterface
                 $locatorServiceId,
                 $this->buildLocatorDefinition($handlerMapping)
             );
+
+            $container->setDefinition(
+                'tactician.commandbus.'.$busId.'.middleware.command_handler',
+                $this->buildCommandHandlerDefinition($locatorServiceId)
+            );
         }
 
         $handlerLocator->addArgument($defaultMapping);
@@ -91,6 +96,22 @@ class CommandHandlerPass implements CompilerPassInterface
             [
                 new Reference('service_container'),
                 $handlerMapping,
+            ]
+        );
+    }
+
+    /**
+     * @param string $locatorServiceId 
+     * @return Definition
+     */
+    protected function buildCommandHandlerDefinition($locatorServiceId)
+    {
+        return new Definition(
+            'League\Tactician\Handler\CommandHandlerMiddleware',
+            [
+                new Reference('tactician.handler.command_name_extractor.class_name'),
+                new Reference($locatorServiceId),
+                new Reference('tactician.handler.method_name_inflector.handle')
             ]
         );
     }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -25,7 +25,8 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $handlerLocator = $container->findDefinition('tactician.handler.locator.symfony');
 
-        $mapping = [];
+        $defaultMapping = [];
+        $busIdToHandlerMapping = [];
 
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
 
@@ -35,14 +36,15 @@ class CommandHandlerPass implements CompilerPassInterface
                 }
 
                 if (isset($attributes['bus'])) {
-                    $this->abortIfInvalidBusId($id, $container);
+                    $this->abortIfInvalidBusId($attributes['bus'], $container);
+                    $busIdToHandlerMapping[$attributes['bus']][$attributes['command']] = $id;
+                } else {
+                    $defaultMapping[$attributes['command']] = $id;
                 }
-
-                $mapping[$attributes['command']] = $id;
             }
         }
 
-        $handlerLocator->addArgument($mapping);
+        $handlerLocator->addArgument($defaultMapping);
     }
 
     protected function abortIfInvalidBusId($id, ContainerBuilder $container)

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -21,7 +21,6 @@ class CommandHandlerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $defaultMapping = [];
         $defaultBusId = $this->getDefaultBusId($container);
         $busIdToHandlerMapping = [];
 

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -27,10 +27,19 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $mapping = [];
 
+        $config = $container->getExtensionConfig('tactician');
+
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
+
             foreach ($tags as $attributes) {
                 if (!isset($attributes['command'])) {
                     throw new \Exception('The tactician.handler tag must always have a command attribute');
+                }
+
+                if (isset($attributes['bus'])) {
+                    if (!array_key_exists($attributes['bus'], $config['commandbus'])) {
+                        throw new \Exception('Invalid bus id "'.$attributes['bus'].'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
+                    }
                 }
 
                 $mapping[$attributes['command']] = $id;

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -66,6 +66,11 @@ class CommandHandlerPass implements CompilerPassInterface
             'tactician.commandbus.'.$defaultBusId.'.handler.locator'
         );
 
+        $container->setAlias(
+            'tactician.middleware.command_handler',
+            'tactician.commandbus.'.$defaultBusId.'.middleware.command_handler'
+        );
+
         $handlerLocator->addArgument($defaultMapping);
     }
 

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -21,7 +21,6 @@ class TacticianExtension extends ConfigurableExtension
         $loader->load('services.yml');
 
         $this->configureCommandBuses($mergedConfig, $container);
-        $this->injectMethodNameInflector($mergedConfig, $container);
     }
 
     public function getAlias()
@@ -51,24 +50,5 @@ class TacticianExtension extends ConfigurableExtension
                 $container->setAlias('tactician.commandbus', $serviceName);
             }
         }
-    }
-
-    /**
-     * Define the default Method Name Inflector.
-     * This will fail silently if the command_handler service does not exist
-     *
-     * @param array $mergedConfig
-     * @param ContainerBuilder $container
-     */
-    private function injectMethodNameInflector(array $mergedConfig, ContainerBuilder $container)
-    {
-        if (! $container->has('tactician.middleware.command_handler')) {
-            return;
-        }
-
-        $inflectorReference = new Reference($mergedConfig['method_inflector']);
-
-        $handlerLocator = $container->findDefinition('tactician.middleware.command_handler');
-        $handlerLocator->replaceArgument(2, $inflectorReference);
     }
 }

--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -26,6 +26,10 @@ class ContainerBasedHandlerLocator implements HandlerLocator
      */
     public function __construct(ContainerInterface $container, $commandToServiceIdMapping)
     {
+        if (empty($commandToServiceIdMapping)) {
+            throw new \InvalidArgumentException('commandToServiceIdMapping cannot be empty');
+        }
+
         $this->container = $container;
         $this->commandToServiceId = $commandToServiceIdMapping;
     }

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -2,19 +2,6 @@ parameters:
   tactician.commandbus.class: League\Tactician\CommandBus
 
 services:
-    tactician.handler.locator.symfony:
-        class: League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator
-        arguments:
-            - "@service_container"
-
-    # The standard middleware
-    tactician.middleware.command_handler:
-        class: League\Tactician\Handler\CommandHandlerMiddleware
-        arguments:
-            - "@tactician.handler.command_name_extractor.class_name"
-            - "@tactician.handler.locator.symfony"
-            - "@tactician.handler.method_name_inflector.handle"
-
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -171,4 +171,48 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->compiler->process($this->container);
     }
+
+    public function testProcessAddsLocatorDefinitionForTaggedBuses()
+    {
+        $definition = \Mockery::mock(Definition::class);
+
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn([
+                'commandbus' => [
+                    'custom_bus' => []
+                ]
+            ]);
+
+        $this->container->shouldReceive('has')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn(true);
+
+        $this->container->shouldReceive('findDefinition')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn($definition);
+
+        $this->container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn([
+                'service_id_1' => [
+                    ['command' => 'my_command', 'bus' => 'custom_bus']
+                ],
+            ]);
+
+        $this->container->shouldReceive('setDefinition')
+            ->with(
+                'tactician.handler.locator.symfony.custom_bus',
+                \Mockery::type('Symfony\Component\DependencyInjection\Definition')
+            );
+
+        $definition->shouldReceive('addArgument')
+            ->once();
+
+        $this->compiler->process($this->container);
+    }
 }

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -176,7 +176,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->compiler->process($this->container);
     }
 
-    public function testProcessAddsLocatorDefinitionForTaggedBuses()
+    public function testProcessAddsLocatorAndHandlerDefinitionForTaggedBuses()
     {
         $definition = \Mockery::mock(Definition::class);
 
@@ -212,6 +212,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->container->shouldReceive('setDefinition')
             ->with(
                 'tactician.commandbus.custom_bus.handler.locator',
+                \Mockery::type('Symfony\Component\DependencyInjection\Definition')
+            );
+
+        $this->container->shouldReceive('setDefinition')
+            ->with(
+                'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -83,7 +83,11 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('getExtensionConfig')
             ->with('tactician')
-            ->once();
+            ->twice()
+            ->andReturn([
+                'default_bus' => 'default',
+                'commandbus' => []
+            ]);
 
         $this->container->shouldReceive('findTaggedServiceIds')
             ->with('tactician.handler')

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -71,8 +71,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.handler.locator.symfony',
                 'tactician.commandbus.default.handler.locator'
             )
-            ->once()
-            ->andReturn($definition);
+            ->once();
 
         $definition->shouldReceive('addArgument')
             ->once();

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -73,6 +73,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             )
             ->once();
 
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.middleware.command_handler',
+                'tactician.commandbus.default.middleware.command_handler'
+            )
+            ->once();
+
         $definition->shouldReceive('addArgument')
             ->once();
 
@@ -237,6 +244,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with(
                 'tactician.handler.locator.symfony',
                 'tactician.commandbus.custom_bus.handler.locator'
+            )
+            ->once();
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.middleware.command_handler',
+                'tactician.commandbus.custom_bus.middleware.command_handler'
             )
             ->once();
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -34,7 +34,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('getExtensionConfig')
             ->with('tactician')
-            ->once();
+            ->andReturn([
+                'default_bus' => 'default',
+                'commandbus' => [
+                    'default' => []
+                ]
+            ]);
 
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
@@ -60,6 +65,14 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('setDefinition')
             ->twice();
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.handler.locator.symfony',
+                'tactician.commandbus.default.handler.locator'
+            )
+            ->once()
+            ->andReturn($definition);
 
         $definition->shouldReceive('addArgument')
             ->once();
@@ -184,7 +197,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
-                'default_bus' => 'default',
+                'default_bus' => 'custom_bus',
                 'commandbus' => [
                     'custom_bus' => []
                 ]
@@ -220,6 +233,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.handler.locator.symfony',
+                'tactician.commandbus.custom_bus.handler.locator'
+            )
+            ->once();
 
         $definition->shouldReceive('addArgument')
             ->once();

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -32,6 +32,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -67,6 +71,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -91,6 +99,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -110,6 +122,47 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ],
                 'service_id_2' => [
                     ['command' => 'my_command']
+                ],
+            ]);
+
+        $definition->shouldReceive('addArgument')
+            ->never();
+
+        $this->compiler->process($this->container);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testProcessAbortsOnInvalidBus()
+    {
+        $definition = \Mockery::mock(Definition::class);
+
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn([
+                'commandbus' => [
+                    'default' => []
+                ]
+            ]);
+
+        $this->container->shouldReceive('has')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn(true);
+
+        $this->container->shouldReceive('findDefinition')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn($definition);
+
+        $this->container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn([
+                'service_id_1' => [
+                    ['command' => 'my_command', 'bus' => 'bad_bus_name']
                 ],
             ]);
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -58,6 +58,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ],
             ]);
 
+        $this->container->shouldReceive('setDefinition')
+            ->twice();
+
         $definition->shouldReceive('addArgument')
             ->once();
 
@@ -142,6 +145,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
+                'default_bus' => 'default',
                 'commandbus' => [
                     'default' => []
                 ]
@@ -180,6 +184,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
+                'default_bus' => 'default',
                 'commandbus' => [
                     'custom_bus' => []
                 ]
@@ -206,7 +211,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('setDefinition')
             ->with(
-                'tactician.handler.locator.symfony.custom_bus',
+                'tactician.commandbus.custom_bus.handler.locator',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
 

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -98,27 +98,4 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->load();
         $this->assertContainerBuilderHasService('tactician.commandbus.default');
     }
-
-    public function testMethodNameInflectorDefault()
-    {
-        $this->load();
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'tactician.middleware.command_handler',
-            2,
-            new Reference('tactician.handler.method_name_inflector.handle')
-        );
-    }
-
-    public function testMethodNameInflectorNonDefault()
-    {
-        $this->load([
-            'method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name_without_suffix'
-        ]);
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'tactician.middleware.command_handler',
-            2,
-            new Reference('tactician.handler.method_name_inflector.handle_class_name_without_suffix')
-        );
-    }
 }


### PR DESCRIPTION
Addresses #19 

There are a number of different possible ways that this feature could be implemented. Currently the bundle places all tagged handlers into a single instance of ContainerBasedHandlerLocator and relies on the user to register this handler as a middleware of their bus (or use the default tactician.middleware.command_handler service which includes it).

The approach I took was to leave that as-is for any handlers which are explicitly tagged as belonging to a specific bus. 

However if the user tags a handler for a specific bus by using the "bus" key in the tag definition then this code does the following:
1. Do not add the handler to the default locator
2. Create a new service called tactician.handler.locator.symfony._bus_name_ with only those handlers tagged explicitly for that bus

This means that if you want as soon as you tag a handler for a specific bus, that bus will now ONLY include handlers explicitly tagged for it.

This also means that the user needs to be sure they configure the bus with an instance of CommandHandlerMiddleware since they can't use the default tactician.middleware.command_handler

There are some other possible approaches improvements I thought of, I wanted to post this WIP code and get feedback before I proceed any further. Here are some other ideas
1. Create a copy of the tactician.middleware.command_handler for each bus that has handlers tagged for it explicitly. This would be identical to the default command_handler but with a different locator. The user would still need to attach the right tactician.middleware.command_handler.BUS_NAME as the final middleware. 
2. Automatically push the command_handler onto the middleware for the bus (deviates from the way this bundle works right now where you have to include the command handler as the final middleware) 
3. If the user configures multiple buses we could throw an exception if they dont tag all their handler services (probably not a good idea)

@rosstuck @boekkooi Let me know your thoughts, It seems like at least the first item would be necessary to make this feature easy to use (automatically create a copy of the default command_handler middleware with the custom locator if the user tags any of their handler services)
