### PR TITLE
Security middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"
     - php: 5.6
-      env: SYMFONY_VERSION="2.7.*"
-    - php: 5.6
       env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
       env: SYMFONY_VERSION="3.0.*"

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                 ->end()
                 ->arrayNode('security')
+                    ->defaultValue([])
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()
                 ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('tactician.handler.method_name_inflector.handle')
                     ->cannotBeEmpty()
                 ->end()
+                ->arrayNode('security')
+                    ->useAttributeAsKey('name')
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
             ->validate()
                 ->ifTrue(function($config) {

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -84,7 +84,7 @@ class TacticianExtension extends ConfigurableExtension
     {
         foreach ($mergedConfig['commandbus'] as $commandBusConfig) {
             if (in_array('tactician.middleware.security', $commandBusConfig['middleware'])) {
-                $this->configureCommandSecurityVoter($mergedConfig, $container);
+                return $this->configureCommandSecurityVoter($mergedConfig, $container);
             }
         }
     }

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -1,9 +1,10 @@
 <?php namespace League\Tactician\Bundle\DependencyInjection;
 
+use League\Tactician\Bundle\Security\Voter\HandleCommandVoter;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
@@ -22,6 +23,7 @@ class TacticianExtension extends ConfigurableExtension
 
         $this->configureCommandBuses($mergedConfig, $container);
         $this->injectMethodNameInflector($mergedConfig, $container);
+        $this->configureSecurity($mergedConfig, $container);
     }
 
     public function getAlias()
@@ -70,5 +72,25 @@ class TacticianExtension extends ConfigurableExtension
 
         $handlerLocator = $container->findDefinition('tactician.middleware.command_handler');
         $handlerLocator->replaceArgument(2, $inflectorReference);
+    }
+
+    /**
+     * Configure the security voter.
+     *
+     * @param array $mergedConfig
+     * @param ContainerBuilder $container
+     */
+    private function configureSecurity(array $mergedConfig, ContainerBuilder $container)
+    {
+        if (!$container->has('tactician.middleware.security_voter')) {
+            $definition = new Definition(
+                HandleCommandVoter::class,
+                [
+                    new Reference('security.access.decision_manager'),
+                    $mergedConfig['security']
+                ]
+            );
+            $container->setDefinition('tactician.middleware.security_voter', $definition);
+        }
     }
 }

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -90,6 +90,7 @@ class TacticianExtension extends ConfigurableExtension
                     $mergedConfig['security']
                 ]
             );
+            $definition->addTag('security.voter');
             $container->setDefinition('tactician.middleware.security_voter', $definition);
         }
     }

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -75,12 +75,27 @@ class TacticianExtension extends ConfigurableExtension
     }
 
     /**
-     * Configure the security voter.
+     * Configure the security voter if the security middleware is loaded.
      *
      * @param array $mergedConfig
      * @param ContainerBuilder $container
      */
     private function configureSecurity(array $mergedConfig, ContainerBuilder $container)
+    {
+        foreach ($mergedConfig['commandbus'] as $commandBusConfig) {
+            if (in_array('tactician.middleware.security', $commandBusConfig['middleware'])) {
+                $this->configureCommandSecurityVoter($mergedConfig, $container);
+            }
+        }
+    }
+
+    /**
+     * Configure the security voter.
+     *
+     * @param array $mergedConfig
+     * @param ContainerBuilder $container
+     */
+    private function configureCommandSecurityVoter(array $mergedConfig, ContainerBuilder $container)
     {
         if (!$container->has('tactician.middleware.security_voter')) {
             $definition = new Definition(

--- a/Middleware/SecurityMiddleware.php
+++ b/Middleware/SecurityMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace League\Tactician\Bundle\Middleware;
+
+use League\Tactician\Exception\InvalidMiddlewareException;
+use League\Tactician\Middleware;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+
+class SecurityMiddleware implements Middleware
+{
+    /**
+     * Access denied behavior to drop the command if not allowed.
+     */
+    const DROP_COMMAND = 1;
+
+    /**
+     * Access denied behavior to throw an AccessDenied exception if not allowed.
+     * Default behavior.
+     */
+    const THROW_ACCESS_DENIED_EXCEPTION = 2;
+
+    /**
+     * @var int
+     */
+    private $accessDeniedBehavior;
+
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    /**
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     */
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, $accessDeniedBehavior = self::THROW_ACCESS_DENIED_EXCEPTION) {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->accessDeniedBehavior = $accessDeniedBehavior;
+
+        if ($this->accessDeniedBehavior !== static::DROP_COMMAND && $this->accessDeniedBehavior !== static::THROW_ACCESS_DENIED_EXCEPTION) {
+            throw new InvalidMiddlewareException(
+                sprintf('The security middleware requires a valid accessDeniedBehavior, \'%s\' is not valid.', $this->accessDeniedBehavior)
+            );
+        }
+    }
+
+    /**
+     * @param object $command
+     * @param callable $next
+     * @return mixed
+     */
+    public function execute($command, callable $next)
+    {
+        if ($this->authorizationChecker->isGranted('handle', $command)) {
+            return $next($command);
+        } elseif ($this->accessDeniedBehavior === static::THROW_ACCESS_DENIED_EXCEPTION) {
+            throw new AccessDeniedException(
+                sprintf('The current user is not allowed to handle command of type \'%s\'', get_class($command))
+            );
+        }
+    }
+}
+

--- a/Middleware/SecurityMiddleware.php
+++ b/Middleware/SecurityMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace League\Tactician\Bundle\Middleware;
 
-use League\Tactician\Exception\InvalidMiddlewareException;
 use League\Tactician\Middleware;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -11,22 +10,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class SecurityMiddleware implements Middleware
 {
     /**
-     * Access denied behavior to drop the command if not allowed.
-     */
-    const DROP_COMMAND = 1;
-
-    /**
-     * Access denied behavior to throw an AccessDenied exception if not allowed.
-     * Default behavior.
-     */
-    const THROW_ACCESS_DENIED_EXCEPTION = 2;
-
-    /**
-     * @var int
-     */
-    private $accessDeniedBehavior;
-
-    /**
      * @var AuthorizationCheckerInterface
      */
     private $authorizationChecker;
@@ -34,15 +17,8 @@ class SecurityMiddleware implements Middleware
     /**
      * @param AuthorizationCheckerInterface $authorizationChecker
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, $accessDeniedBehavior = self::THROW_ACCESS_DENIED_EXCEPTION) {
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker) {
         $this->authorizationChecker = $authorizationChecker;
-        $this->accessDeniedBehavior = $accessDeniedBehavior;
-
-        if ($this->accessDeniedBehavior !== static::DROP_COMMAND && $this->accessDeniedBehavior !== static::THROW_ACCESS_DENIED_EXCEPTION) {
-            throw new InvalidMiddlewareException(
-                sprintf('The security middleware requires a valid accessDeniedBehavior, \'%s\' is not valid.', $this->accessDeniedBehavior)
-            );
-        }
     }
 
     /**
@@ -54,7 +30,7 @@ class SecurityMiddleware implements Middleware
     {
         if ($this->authorizationChecker->isGranted('handle', $command)) {
             return $next($command);
-        } elseif ($this->accessDeniedBehavior === static::THROW_ACCESS_DENIED_EXCEPTION) {
+        } else {
             throw new AccessDeniedException(
                 sprintf('The current user is not allowed to handle command of type \'%s\'', get_class($command))
             );

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ tactician:
             - 'ROLE_ADMIN'
 ```
 
+The Security middleware is disabled by default.
+
 #### Command Handler Middleware (tactician.middleware.command_handler)
 
 **Always ensure this is the last middleware listed**

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ The middleware will throw an `InvalidCommandException` that will contain the com
 
 This middleware is bundled in Tactician, please refer to [the official documentation](http://tactician.thephpleague.com/plugins/locking-middleware/) for details.
 
+#### Security Middleware (tactician.middleware.security)
+
+The security middleware will perform authorization on handling all commands. By default an AccessDenied exception will be thrown if the user is not authorized. You must configure one or more roles for each command to allow handling:
+
+```yaml
+tactician:
+    security:
+        My\User\Command:
+            - 'ROLE_USER'
+        My\Admin\Command:
+            - 'ROLE_ADMIN'
+        My\UserAndAdmin\Command:
+            - 'ROLE_USER'
+            - 'ROLE_ADMIN'
+```
+
 #### Command Handler Middleware (tactician.middleware.command_handler)
 
 **Always ensure this is the last middleware listed**

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -23,6 +23,11 @@ services:
         arguments:
             - "@?validator"
 
+    tactician.middleware.security:
+        class: League\Tactician\Bundle\Middleware\SecurityMiddleware
+        arguments:
+            - "@security.authorization_checker"
+
     # The standard Handler method name inflectors
     tactician.handler.method_name_inflector.handle:
         class: League\Tactician\Handler\MethodNameInflector\HandleInflector

--- a/Security/Voter/HandleCommandVoter.php
+++ b/Security/Voter/HandleCommandVoter.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace League\Tactician\Bundle\Security\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Voter for security checks on handling commands.
+ *
+ * @author Ron Rademaker
+ */
+class HandleCommandVoter extends Voter
+{
+    /**
+     * The decision manager.
+     *
+     * @var AccessDecisionManagerInterface
+     */
+    private $decisionManager;
+
+    /**
+     * Command - Require role mapping
+     *
+     * @var array
+     */
+    private $commandRoleMapping;
+
+    /**
+     * Create a new HandleCommandVoter.
+     *
+     * @param AccessDecisionManagerInterface $decisionManager
+     * @param array $commandRoleMapping
+     * @param string $defaultRole
+     */
+    public function __construct(AccessDecisionManagerInterface $decisionManager, array $commandRoleMapping = [])
+    {
+        $this->decisionManager = $decisionManager;
+        $this->commandRoleMapping = $commandRoleMapping;
+    }
+
+    /**
+     * The voter supports checking handle commands
+     *
+     * @param string $attribute
+     * @param object $subject
+     * @return bool
+     */
+    protected function supports($attribute, $subject)
+    {
+        return $attribute === 'handle' && is_object($subject);
+    }
+
+    /**
+     * Checks if the currently logged on user may handle $subject.
+     *
+     * @param type $attribute
+     * @param type $subject
+     * @param TokenInterface $token
+     *
+     * @return bool
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $allowedRoles = $this->getAllowedRoles(get_class($subject));
+
+        if (count($allowedRoles) > 0) {
+            return $this->decisionManager->decide($token, $allowedRoles);
+        } else {
+            // default conclusion is access denied
+            return false;
+        }
+    }
+
+    /**
+     * Gets the roles allowed to handle a command of $type
+     *
+     * @param string $type
+     * @return array
+     */
+    private function getAllowedRoles($type)
+    {
+        if (array_key_exists($type, $this->commandRoleMapping)) {
+            return $this->commandRoleMapping[$type];
+        } else {
+            return [];
+        }
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -203,4 +203,24 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             ]
         );
     }
+
+    public function testSecurityConfiguration()
+        {
+        $this->assertConfigurationIsValid([
+            'tactician' => [
+                'commandbus' => [
+                    'default' => [
+                        'middleware' => [
+                            'my_middleware'  => 'some_middleware',
+                            'my_middleware2' => 'some_middleware',
+                        ]
+                    ]
+                ],
+                'security' => [
+                    'Some\Command' => 'ROLE_USER',
+                    'Some\Other\Command' => 'ROLE_ADMIN',
+                ]
+            ]
+        ]);
+    }
 }

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -121,4 +121,13 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
             new Reference('tactician.handler.method_name_inflector.handle_class_name_without_suffix')
         );
     }
+
+    public function testLoadSecurityConfiguration()
+    {
+        $securitySettings = ['Some\Command' => 'ROLE_USER', 'Some\Other\Command' => 'ROLE_ADMIN'];
+
+        $this->load(['security' => $securitySettings]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, $securitySettings);
+    }
 }

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -129,5 +129,6 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->load(['security' => $securitySettings]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, $securitySettings);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('tactician.middleware.security_voter', 'security.voter');
     }
 }

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -131,4 +131,12 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, $securitySettings);
         $this->assertContainerBuilderHasServiceDefinitionWithTag('tactician.middleware.security_voter', 'security.voter');
     }
+
+    public function testDefaultSecurityConfigurationIsAllowNothing()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, []);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('tactician.middleware.security_voter', 'security.voter');
+    }
 }

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -126,7 +126,17 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
     {
         $securitySettings = ['Some\Command' => 'ROLE_USER', 'Some\Other\Command' => 'ROLE_ADMIN'];
 
-        $this->load(['security' => $securitySettings]);
+        $this->load([
+            'commandbus' => [
+                'default' => [
+                    'middleware' => [
+                        'tactician.middleware.security',
+                        'tactician.middleware.command_handler',
+                    ]
+                ]
+            ],
+            'security' => $securitySettings
+        ]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, $securitySettings);
         $this->assertContainerBuilderHasServiceDefinitionWithTag('tactician.middleware.security_voter', 'security.voter');
@@ -134,9 +144,25 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
 
     public function testDefaultSecurityConfigurationIsAllowNothing()
     {
-        $this->load();
+        $this->load([
+            'commandbus' => [
+                'default' => [
+                    'middleware' => [
+                        'tactician.middleware.security',
+                        'tactician.middleware.command_handler',
+                    ]
+                ]
+            ]
+        ]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('tactician.middleware.security_voter', 1, []);
         $this->assertContainerBuilderHasServiceDefinitionWithTag('tactician.middleware.security_voter', 'security.voter');
+    }
+
+    public function testVoterIsNotLoadedWithoutSecurityMiddleware()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderNotHasService('tactician.middleware.security_voter');
     }
 }

--- a/Tests/Middleware/SecurityMiddlewareTest.php
+++ b/Tests/Middleware/SecurityMiddlewareTest.php
@@ -60,28 +60,4 @@ class SecurityMiddlewareTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($handled);
     }
-
-    /**
-     * Tests the command is not handled if access is denied and the command is just dropped if the drop behavior is set.
-     */
-    public function testAccessIsNotGrantedCommandIsDropped()
-    {
-        $this->authorizationChecker->shouldReceive('isGranted')->andReturn(false);
-        $middleware = new SecurityMiddleware($this->authorizationChecker, SecurityMiddleware::DROP_COMMAND);
-        $handled = false;
-        $middleware->execute(new FakeCommand(), function () use(&$handled) {
-            $handled = true;
-        });
-
-        $this->assertFalse($handled);
-    }
-
-    /**
-     * Tests if an exception if thrown if passing in an invalid behavior.
-     */
-    public function testExceptionForInvalidBehavior()
-    {
-        $this->setExpectedException(InvalidMiddlewareException::class);
-        new SecurityMiddleware($this->authorizationChecker, -1);
-    }
 }

--- a/Tests/Middleware/SecurityMiddlewareTest.php
+++ b/Tests/Middleware/SecurityMiddlewareTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests\Middleware;
+
+use League\Tactician\Bundle\Middleware\SecurityMiddleware;
+use League\Tactician\Bundle\Tests\Fake\FakeCommand;
+use League\Tactician\Exception\InvalidMiddlewareException;
+use Mockery;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Unit test for the security middleware.
+ *
+ * @author Ron Rademaker
+ */
+class SecurityMiddlewareTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Authorization checker mock.
+     */
+    private $authorizationChecker;
+
+    /**
+     * Set up.
+     */
+    public function setUp()
+    {
+        $this->authorizationChecker = Mockery::mock(AuthorizationCheckerInterface::class);
+    }
+
+    /**
+     * Tests the command is handled if access is granted.
+     */
+    public function testAccessIsGranted()
+    {
+        $this->authorizationChecker->shouldReceive('isGranted')->andReturn(true);
+        $middleware = new SecurityMiddleware($this->authorizationChecker);
+        $handled = false;
+        $middleware->execute(new FakeCommand(), function () use(&$handled) {
+            $handled = true;
+        });
+
+        $this->assertTrue($handled);
+    }
+
+    /**
+     * Tests the command is not handled if access is denied and an AccessDenied exception is thrown.
+     */
+    public function testAccessIsNotGranted()
+    {
+        $this->setExpectedException(AccessDeniedException::class);
+        $this->authorizationChecker->shouldReceive('isGranted')->andReturn(false);
+        $middleware = new SecurityMiddleware($this->authorizationChecker);
+        $handled = false;
+        $middleware->execute(new FakeCommand(), function () use(&$handled) {
+            $handled = true;
+        });
+
+        $this->assertFalse($handled);
+    }
+
+    /**
+     * Tests the command is not handled if access is denied and the command is just dropped if the drop behavior is set.
+     */
+    public function testAccessIsNotGrantedCommandIsDropped()
+    {
+        $this->authorizationChecker->shouldReceive('isGranted')->andReturn(false);
+        $middleware = new SecurityMiddleware($this->authorizationChecker, SecurityMiddleware::DROP_COMMAND);
+        $handled = false;
+        $middleware->execute(new FakeCommand(), function () use(&$handled) {
+            $handled = true;
+        });
+
+        $this->assertFalse($handled);
+    }
+
+    /**
+     * Tests if an exception if thrown if passing in an invalid behavior.
+     */
+    public function testExceptionForInvalidBehavior()
+    {
+        $this->setExpectedException(InvalidMiddlewareException::class);
+        new SecurityMiddleware($this->authorizationChecker, -1);
+    }
+}

--- a/Tests/Security/Voter/HandleCommandVoterTest.php
+++ b/Tests/Security/Voter/HandleCommandVoterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests\Security\Voter;
+
+use League\Tactician\Bundle\Security\Voter\HandleCommandVoter;
+use League\Tactician\Bundle\Tests\Fake\FakeCommand;
+use Mockery;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Unit test for the handle command voter
+ *
+ * @author Ron Rademaker
+ */
+class HandleCommandVoterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The decision manager mock.
+     */
+    private $decisionManager;
+
+    /**
+     * Set up.
+     */
+    public function setUp()
+    {
+        $this->decisionManager = Mockery::mock(AccessDecisionManager::class);
+    }
+
+    /**
+     * Tests the vote method.
+     *
+     * @param type $attribute
+     * @param type $subject
+     * @param type $decision
+     * @param type $default
+     * @param type $mapping
+     * @param type $expected
+     *
+     * @dataProvider provideTestVoteData
+     */
+    public function testVote($attribute, $subject, $decision, $mapping, $expected)
+    {
+        $this->decisionManager->shouldReceive('decide')->andReturn($decision);
+        $voter = new HandleCommandVoter($this->decisionManager, $mapping);
+        $tokenMock = Mockery::mock(TokenInterface::class);
+
+        $this->assertEquals($expected, $voter->vote($tokenMock, $subject, [$attribute]));
+    }
+
+    /**
+     * Gets the testdata for the vote test.
+     *
+     * @return array
+     */
+    public function provideTestVoteData()
+    {
+        return [
+            ['handle', new FakeCommand, true, [], VoterInterface::ACCESS_DENIED],
+            ['handle', null, true, [], VoterInterface::ACCESS_ABSTAIN],
+            ['create', null, true, [], VoterInterface::ACCESS_ABSTAIN],
+            ['create', new FakeCommand, true, [], VoterInterface::ACCESS_ABSTAIN],
+            ['handle', new FakeCommand, false, [], VoterInterface::ACCESS_DENIED],
+            ['handle', new FakeCommand, false, [FakeCommand::class => ['ROLE_USER']], VoterInterface::ACCESS_DENIED],
+            ['handle', new FakeCommand, true, [FakeCommand::class => ['ROLE_USER']], VoterInterface::ACCESS_GRANTED],
+            ['handle', new FakeCommand, false, ['someOtherCommand' => ['ROLE_USER']], VoterInterface::ACCESS_DENIED],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
   "minimum-stability": "beta",
   "suggest": {
     "symfony/validator": "For command validator middleware",
+    "symfony/security": "For command security middleware",
     "league/tactician-doctrine": "For doctrine transaction middleware"
   },
   "autoload" : {
@@ -56,7 +57,7 @@
     "mockery/mockery": "~0.9.4",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
-
+    "symfony/security": "^3.1",
     "symfony/validator": "^2.3|^3.0",
     "league/tactician-doctrine": "^1.0"
   }

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
   "require" : {
     "php":  ">=5.5",
     "league/tactician": "^1.0",
-    "symfony/config": "^2.3|^3.0",
-    "symfony/dependency-injection": "^2.3|^3.0",
-    "symfony/http-kernel": "^2.3|^3.0",
-    "symfony/yaml": "^2.3|^3.0"
+    "symfony/config": "^2.8|^3.0",
+    "symfony/dependency-injection": "^2.8|^3.0",
+    "symfony/http-kernel": "^2.8|^3.0",
+    "symfony/yaml": "^2.8|^3.0"
   },
   "minimum-stability": "beta",
   "suggest": {
@@ -57,8 +57,8 @@
     "mockery/mockery": "~0.9.4",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
-    "symfony/security": "^2.6|^3.1",
-    "symfony/validator": "^2.3|^3.0",
+    "symfony/security": "^2.8|^3.1",
+    "symfony/validator": "^2.8|^3.0",
     "league/tactician-doctrine": "^1.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "mockery/mockery": "~0.9.4",
     "matthiasnoback/symfony-config-test": "~1.0",
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
-    "symfony/security": "^3.1",
+    "symfony/security": "^2.6|^3.1",
     "symfony/validator": "^2.3|^3.0",
     "league/tactician-doctrine": "^1.0"
   }


### PR DESCRIPTION
This will close #23 

I'm currently thinking about how to implement the actual security checks, I see several options:

* Add a ```Voter``` that reads out some config that maps commands to roles and check if the user has the required roles. This would put all security logic in the security system.
* Instead of the ```Voter``` the mapping could be injected into the middleware, allowing the ```isGranted``` call to be called with the required role instead of the current ```handle```.  People are used to having isGranted called with a role attribute, so the approach is familiar. But not all security will be in the security system, some will be in the commandbus middleware.
* Add a ```SecuredCommand``` interface that has a method ```getRequiredRole```, call ```isGranted``` on that role. Such an approach would be easy to understand and use. But we won't have:

![image](https://cloud.githubusercontent.com/assets/2697738/17057202/d43ce31a-5018-11e6-8314-8e71878d522b.png)

What do you think?