### PR TITLE
Allow tagging handlers per bus

### DIFF
--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -55,7 +55,7 @@ class CommandHandlerPass implements CompilerPassInterface
 
             $container->setDefinition(
                 'tactician.commandbus.'.$busId.'.middleware.command_handler',
-                $this->buildCommandHandlerDefinition($locatorServiceId, $tacticianConfig)
+                $this->buildCommandHandlerDefinition($busId, $locatorServiceId, $tacticianConfig)
             );
         }
 
@@ -98,20 +98,29 @@ class CommandHandlerPass implements CompilerPassInterface
     }
 
     /**
+     * @param string $busId
      * @param string $locatorServiceId
      * @param array $config
      * @return Definition
      */
-    protected function buildCommandHandlerDefinition($locatorServiceId, array $config)
+    protected function buildCommandHandlerDefinition($busId, $locatorServiceId, array $config)
     {
         return new Definition(
             CommandHandlerMiddleware::class,
             [
                 new Reference('tactician.handler.command_name_extractor.class_name'),
                 new Reference($locatorServiceId),
-                new Reference($config['method_inflector'])
+                new Reference($this->methodInflectorOfBus($busId, $config))
             ]
         );
     }
 
+    private function methodInflectorOfBus($busId, array $config)
+    {
+        if (array_key_exists('method_inflector', $config['commandbus'][$busId])) {
+            return $config['commandbus'][$busId]['method_inflector'];
+        }
+
+        return $config['method_inflector'];
+    }
 }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -39,8 +39,8 @@ class CommandHandlerPass implements CompilerPassInterface
                     $this->abortIfInvalidBusId($attributes['bus'], $busIds);
                 }
 
-                $busIds = array_key_exists('bus', $attributes) ? [$attributes['bus']] : $busIds;
-                foreach ($busIds as $busId) {
+                $busIdsDefined = array_key_exists('bus', $attributes) ? [$attributes['bus']] : $busIds;
+                foreach ($busIdsDefined as $busId) {
                     $busIdToHandlerMapping[$busId][$attributes['command']] = $id;
                 }
             }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -1,6 +1,8 @@
 <?php
 namespace League\Tactician\Bundle\DependencyInjection\Compiler;
 
+use League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator;
+use League\Tactician\Handler\CommandHandlerMiddleware;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -91,7 +93,7 @@ class CommandHandlerPass implements CompilerPassInterface
     protected function buildLocatorDefinition(array $handlerMapping)
     {
         return new Definition(
-            'League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator',
+            ContainerBasedHandlerLocator::class,
             [
                 new Reference('service_container'),
                 $handlerMapping,
@@ -108,7 +110,7 @@ class CommandHandlerPass implements CompilerPassInterface
         $config = $container->getExtensionConfig('tactician');
 
         return new Definition(
-            'League\Tactician\Handler\CommandHandlerMiddleware',
+            CommandHandlerMiddleware::class,
             [
                 new Reference('tactician.handler.command_name_extractor.class_name'),
                 new Reference($locatorServiceId),

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -61,6 +61,11 @@ class CommandHandlerPass implements CompilerPassInterface
             );
         }
 
+        $container->setAlias(
+            'tactician.handler.locator.symfony',
+            'tactician.commandbus.'.$defaultBusId.'.handler.locator'
+        );
+
         $handlerLocator->addArgument($defaultMapping);
     }
 

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -31,11 +31,9 @@ class CommandHandlerPass implements CompilerPassInterface
                     throw new \Exception('The tactician.handler tag must always have a command attribute');
                 }
 
-                if (array_key_exists('bus', $attributes)) {
-                    $this->abortIfInvalidBusId($attributes['bus'], $container);
-                }
-
                 $busId = array_key_exists('bus', $attributes) ? $attributes['bus'] : $defaultBusId;
+
+                $this->abortIfInvalidBusId($busId, $container);
 
                 $busIdToHandlerMapping[$busId][$attributes['command']] = $id;
             }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -27,8 +27,6 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $mapping = [];
 
-        $config = $container->getExtensionConfig('tactician');
-
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
 
             foreach ($tags as $attributes) {
@@ -37,9 +35,7 @@ class CommandHandlerPass implements CompilerPassInterface
                 }
 
                 if (isset($attributes['bus'])) {
-                    if (!array_key_exists($attributes['bus'], $config['commandbus'])) {
-                        throw new \Exception('Invalid bus id "'.$attributes['bus'].'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
-                    }
+                    $this->abortIfInvalidBusId($id, $container);
                 }
 
                 $mapping[$attributes['command']] = $id;
@@ -47,6 +43,15 @@ class CommandHandlerPass implements CompilerPassInterface
         }
 
         $handlerLocator->addArgument($mapping);
+    }
+
+    protected function abortIfInvalidBusId($id, ContainerBuilder $container)
+    {
+        $config = $container->getExtensionConfig('tactician');
+
+        if (!array_key_exists($id, $config['commandbus'])) {
+            throw new \Exception('Invalid bus id "'.$id.'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
+        }
     }
 
 }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -54,6 +54,11 @@ class CommandHandlerPass implements CompilerPassInterface
                 $locatorServiceId,
                 $this->buildLocatorDefinition($handlerMapping)
             );
+
+            $container->setDefinition(
+                'tactician.commandbus.'.$busId.'.middleware.command_handler',
+                $this->buildCommandHandlerDefinition($locatorServiceId)
+            );
         }
 
         $handlerLocator->addArgument($defaultMapping);
@@ -91,6 +96,22 @@ class CommandHandlerPass implements CompilerPassInterface
             [
                 new Reference('service_container'),
                 $handlerMapping,
+            ]
+        );
+    }
+
+    /**
+     * @param string $locatorServiceId 
+     * @return Definition
+     */
+    protected function buildCommandHandlerDefinition($locatorServiceId)
+    {
+        return new Definition(
+            'League\Tactician\Handler\CommandHandlerMiddleware',
+            [
+                new Reference('tactician.handler.command_name_extractor.class_name'),
+                new Reference($locatorServiceId),
+                new Reference('tactician.handler.method_name_inflector.handle')
             ]
         );
     }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -25,7 +25,8 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $handlerLocator = $container->findDefinition('tactician.handler.locator.symfony');
 
-        $mapping = [];
+        $defaultMapping = [];
+        $busIdToHandlerMapping = [];
 
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
 
@@ -35,14 +36,15 @@ class CommandHandlerPass implements CompilerPassInterface
                 }
 
                 if (isset($attributes['bus'])) {
-                    $this->abortIfInvalidBusId($id, $container);
+                    $this->abortIfInvalidBusId($attributes['bus'], $container);
+                    $busIdToHandlerMapping[$attributes['bus']][$attributes['command']] = $id;
+                } else {
+                    $defaultMapping[$attributes['command']] = $id;
                 }
-
-                $mapping[$attributes['command']] = $id;
             }
         }
 
-        $handlerLocator->addArgument($mapping);
+        $handlerLocator->addArgument($defaultMapping);
     }
 
     protected function abortIfInvalidBusId($id, ContainerBuilder $container)

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -21,7 +21,6 @@ class CommandHandlerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $defaultMapping = [];
         $defaultBusId = $this->getDefaultBusId($container);
         $busIdToHandlerMapping = [];
 

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -27,10 +27,19 @@ class CommandHandlerPass implements CompilerPassInterface
 
         $mapping = [];
 
+        $config = $container->getExtensionConfig('tactician');
+
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
+
             foreach ($tags as $attributes) {
                 if (!isset($attributes['command'])) {
                     throw new \Exception('The tactician.handler tag must always have a command attribute');
+                }
+
+                if (isset($attributes['bus'])) {
+                    if (!array_key_exists($attributes['bus'], $config['commandbus'])) {
+                        throw new \Exception('Invalid bus id "'.$attributes['bus'].'". Valid buses are: '.implode(', ', array_keys($config['commandbus'])));
+                    }
                 }
 
                 $mapping[$attributes['command']] = $id;

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -66,6 +66,11 @@ class CommandHandlerPass implements CompilerPassInterface
             'tactician.commandbus.'.$defaultBusId.'.handler.locator'
         );
 
+        $container->setAlias(
+            'tactician.middleware.command_handler',
+            'tactician.commandbus.'.$defaultBusId.'.middleware.command_handler'
+        );
+
         $handlerLocator->addArgument($defaultMapping);
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,8 +45,8 @@ class Configuration implements ConfigurationInterface
                                     )
                                 ->end()
                             ->end()
+                            ->scalarNode('method_inflector')->end()
                         ->end()
-
                     ->end()
                 ->end()
                 ->scalarNode('default_bus')

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -22,7 +22,6 @@ class TacticianExtension extends ConfigurableExtension
         $loader->load('services.yml');
 
         $this->configureCommandBuses($mergedConfig, $container);
-        $this->injectMethodNameInflector($mergedConfig, $container);
         $this->configureSecurity($mergedConfig, $container);
     }
 
@@ -53,25 +52,6 @@ class TacticianExtension extends ConfigurableExtension
                 $container->setAlias('tactician.commandbus', $serviceName);
             }
         }
-    }
-
-    /**
-     * Define the default Method Name Inflector.
-     * This will fail silently if the command_handler service does not exist
-     *
-     * @param array $mergedConfig
-     * @param ContainerBuilder $container
-     */
-    private function injectMethodNameInflector(array $mergedConfig, ContainerBuilder $container)
-    {
-        if (! $container->has('tactician.middleware.command_handler')) {
-            return;
-        }
-
-        $inflectorReference = new Reference($mergedConfig['method_inflector']);
-
-        $handlerLocator = $container->findDefinition('tactician.middleware.command_handler');
-        $handlerLocator->replaceArgument(2, $inflectorReference);
     }
 
     /**

--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -26,6 +26,10 @@ class ContainerBasedHandlerLocator implements HandlerLocator
      */
     public function __construct(ContainerInterface $container, $commandToServiceIdMapping)
     {
+        if (empty($commandToServiceIdMapping)) {
+            throw new \InvalidArgumentException('commandToServiceIdMapping cannot be empty');
+        }
+
         $this->container = $container;
         $this->commandToServiceId = $commandToServiceIdMapping;
     }

--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ Tactician offers a list of custom Inflectors, these are all supported.
  * `tactician.handler.method_name_inflector.handle_class_name_without_suffix`
  * `tactician.handler.method_name_inflector.invoke`
 
+When using multiple bus, you can also specify `method_inflector` of particular bus :
+
+```yaml
+tactician:
+    commandbus:
+        command:
+            middleware:
+                - tactician.middleware.command_handler
+        query:
+            middleware:
+                - tactician.middleware.command_handler
+            method_inflector: tactician.handler.method_name_inflector.handle_class_name_without_suffix
+```
+
 ## Using the Command Bus 
 Create a service and inject the command bus:
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ tactician:
                 # ...
 ```
 
+By default, all commands are available in each bus. If you want to make a command available only in a specific bus, you need to specify its id :
+
+```yaml
+foo.user.register_user_handler:
+    class: Foo\User\RegisterUserHandler
+    arguments:
+        - '@foo.user.user_repository'
+    tags:
+        - { name: tactician.handler, command: Foo\User\RegisterUserCommand, bus: queued }
+```
+
 ### Extra Bundled Middleware
 
 This bundles ships with a few pre-configured middlewares, they can be enabled using the method above by just listing their ids.

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -2,19 +2,6 @@ parameters:
   tactician.commandbus.class: League\Tactician\CommandBus
 
 services:
-    tactician.handler.locator.symfony:
-        class: League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator
-        arguments:
-            - "@service_container"
-
-    # The standard middleware
-    tactician.middleware.command_handler:
-        class: League\Tactician\Handler\CommandHandlerMiddleware
-        arguments:
-            - "@tactician.handler.command_name_extractor.class_name"
-            - "@tactician.handler.locator.symfony"
-            - "@tactician.handler.method_name_inflector.handle"
-
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -171,4 +171,48 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->compiler->process($this->container);
     }
+
+    public function testProcessAddsLocatorDefinitionForTaggedBuses()
+    {
+        $definition = \Mockery::mock(Definition::class);
+
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn([
+                'commandbus' => [
+                    'custom_bus' => []
+                ]
+            ]);
+
+        $this->container->shouldReceive('has')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn(true);
+
+        $this->container->shouldReceive('findDefinition')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn($definition);
+
+        $this->container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn([
+                'service_id_1' => [
+                    ['command' => 'my_command', 'bus' => 'custom_bus']
+                ],
+            ]);
+
+        $this->container->shouldReceive('setDefinition')
+            ->with(
+                'tactician.handler.locator.symfony.custom_bus',
+                \Mockery::type('Symfony\Component\DependencyInjection\Definition')
+            );
+
+        $definition->shouldReceive('addArgument')
+            ->once();
+
+        $this->compiler->process($this->container);
+    }
 }

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -9,7 +9,6 @@ use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
 
 class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var ContainerBuilder | MockInterface
      */
@@ -32,44 +31,34 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->andReturn([
+        $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'default',
                 'method_inflector' => 'tactician.handler.method_name_inflector.handle',
                 'commandbus' => [
                     'default' => []
                 ]
-            ]);
+            ]
+        );
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['command' => 'my_command']
                 ],
                 'service_id_2' => [
                     ['command' => 'my_command']
                 ],
-            ]);
+            ]
+        );
 
-        $this->container->shouldReceive('setDefinition')
-            ->twice();
-
-        $this->container->shouldReceive('setAlias')
-            ->with(
-                'tactician.handler.locator.symfony',
-                'tactician.commandbus.default.handler.locator'
-            )
-            ->once();
-
-        $this->container->shouldReceive('setAlias')
-            ->with(
-                'tactician.middleware.command_handler',
-                'tactician.commandbus.default.middleware.command_handler'
-            )
-            ->once();
+        $this->busShouldBeCorrectlyRegisteredInContainer(
+            $this->container,
+            'default',
+            'tactician.handler.method_name_inflector.handle'
+        );
 
         $this->compiler->process($this->container);
     }
@@ -81,18 +70,17 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->twice()
-            ->andReturn([
+        $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'default',
                 'commandbus' => []
-            ]);
+            ]
+        );
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['not_command' => 'my_command']
                 ],
@@ -111,20 +99,19 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->once()
-            ->andReturn([
+         $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'default',
                 'commandbus' => [
                     'default' => []
                 ]
-            ]);
+            ]
+        );
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['command' => 'my_command', 'bus' => 'bad_bus_name']
                 ],
@@ -137,10 +124,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->once()
-            ->andReturn([
+        $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'custom_bus',
                 'method_inflector' => 'tactician.handler.method_name_inflector.handle',
                 'commandbus' => [
@@ -149,10 +135,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             ]);
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['command' => 'my_command', 'bus' => 'custom_bus'],
                     ['command' => 'my_command', 'bus' => 'other_bus'],
@@ -178,10 +163,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->once()
-            ->andReturn([
+        $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'custom_bus',
                 'method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name',
                 'commandbus' => [
@@ -189,10 +173,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             ]);
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['command' => 'my_command', 'bus' => 'custom_bus']
                 ],
@@ -211,10 +194,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->once()
-            ->andReturn([
+        $this->configShouldBe(
+            $this->container,
+            [
                 'default_bus' => 'custom_bus',
                 'method_inflector' => 'tactician.handler.method_name_inflector.handle',
                 'commandbus' => [
@@ -222,10 +204,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ]
             ]);
 
-        $this->container->shouldReceive('findTaggedServiceIds')
-            ->with('tactician.handler')
-            ->once()
-            ->andReturn([
+        $this->servicesTaggedShouldBe(
+            $this->container,
+            [
                 'service_id_1' => [
                     ['command' => 'my_command', 'bus' => 'custom_bus']
                 ],
@@ -238,6 +219,24 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->compiler->process($this->container);
+    }
+
+    private function configShouldBe($container, array $config)
+    {
+        $container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn($config)
+        ;
+    }
+
+    private function servicesTaggedShouldBe($container, array $config)
+    {
+        $container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn($config)
+        ;
     }
 
     private function busShouldBeCorrectlyRegisteredInContainer($container, $busId, $methodInflector)

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -176,7 +176,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->compiler->process($this->container);
     }
 
-    public function testProcessAddsLocatorDefinitionForTaggedBuses()
+    public function testProcessAddsLocatorAndHandlerDefinitionForTaggedBuses()
     {
         $definition = \Mockery::mock(Definition::class);
 
@@ -212,6 +212,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->container->shouldReceive('setDefinition')
             ->with(
                 'tactician.commandbus.custom_bus.handler.locator',
+                \Mockery::type('Symfony\Component\DependencyInjection\Definition')
+            );
+
+        $this->container->shouldReceive('setDefinition')
+            ->with(
+                'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -207,6 +207,39 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->compiler->process($this->container);
     }
 
+    public function testProcessAddsHandlerDefinitionWithSpecificMethodInflector()
+    {
+        $definition = \Mockery::mock(Definition::class);
+
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn([
+                'default_bus' => 'custom_bus',
+                'method_inflector' => 'tactician.handler.method_name_inflector.handle',
+                'commandbus' => [
+                    'custom_bus' => ['method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name']
+                ]
+            ]);
+
+        $this->container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn([
+                'service_id_1' => [
+                    ['command' => 'my_command', 'bus' => 'custom_bus']
+                ],
+            ]);
+
+        $this->busShouldBeCorrectlyRegisteredInContainer(
+            $this->container,
+            'custom_bus',
+            'tactician.handler.method_name_inflector.handle_class_name'
+        );
+
+        $this->compiler->process($this->container);
+    }
+
     private function busShouldBeCorrectlyRegisteredInContainer($container, $busId, $methodInflector)
     {
         $handlerLocatorId = sprintf('tactician.commandbus.%s.handler.locator', $busId);

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -154,13 +154,20 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->once()
             ->andReturn([
                 'service_id_1' => [
-                    ['command' => 'my_command', 'bus' => 'custom_bus']
+                    ['command' => 'my_command', 'bus' => 'custom_bus'],
+                    ['command' => 'my_command', 'bus' => 'other_bus'],
                 ]
             ]);
 
         $this->busShouldBeCorrectlyRegisteredInContainer(
             $this->container,
             'custom_bus',
+            'tactician.handler.method_name_inflector.handle'
+        );
+
+        $this->busShouldBeCorrectlyRegisteredInContainer(
+            $this->container,
+            'other_bus',
             'tactician.handler.method_name_inflector.handle'
         );
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -83,7 +83,11 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('getExtensionConfig')
             ->with('tactician')
-            ->once();
+            ->twice()
+            ->andReturn([
+                'default_bus' => 'default',
+                'commandbus' => []
+            ]);
 
         $this->container->shouldReceive('findTaggedServiceIds')
             ->with('tactician.handler')

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -71,8 +71,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.handler.locator.symfony',
                 'tactician.commandbus.default.handler.locator'
             )
-            ->once()
-            ->andReturn($definition);
+            ->once();
 
         $definition->shouldReceive('addArgument')
             ->once();

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -73,6 +73,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             )
             ->once();
 
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.middleware.command_handler',
+                'tactician.commandbus.default.middleware.command_handler'
+            )
+            ->once();
+
         $definition->shouldReceive('addArgument')
             ->once();
 
@@ -237,6 +244,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with(
                 'tactician.handler.locator.symfony',
                 'tactician.commandbus.custom_bus.handler.locator'
+            )
+            ->once();
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.middleware.command_handler',
+                'tactician.commandbus.custom_bus.middleware.command_handler'
             )
             ->once();
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -34,7 +34,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('getExtensionConfig')
             ->with('tactician')
-            ->once();
+            ->andReturn([
+                'default_bus' => 'default',
+                'commandbus' => [
+                    'default' => []
+                ]
+            ]);
 
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
@@ -60,6 +65,14 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('setDefinition')
             ->twice();
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.handler.locator.symfony',
+                'tactician.commandbus.default.handler.locator'
+            )
+            ->once()
+            ->andReturn($definition);
 
         $definition->shouldReceive('addArgument')
             ->once();
@@ -184,7 +197,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
-                'default_bus' => 'default',
+                'default_bus' => 'custom_bus',
                 'commandbus' => [
                     'custom_bus' => []
                 ]
@@ -220,6 +233,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
+
+        $this->container->shouldReceive('setAlias')
+            ->with(
+                'tactician.handler.locator.symfony',
+                'tactician.commandbus.custom_bus.handler.locator'
+            )
+            ->once();
 
         $definition->shouldReceive('addArgument')
             ->once();

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -168,7 +168,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::on(function (Definition $definition) {
                     $methodNameInflectorServiceId = (string) $definition->getArgument(2);
-                   
+
                     return $methodNameInflectorServiceId === 'tactician.handler.method_name_inflector.handle';
                 })
             );
@@ -225,7 +225,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 'tactician.commandbus.custom_bus.middleware.command_handler',
                 \Mockery::on(function (Definition $definition) {
                     $methodNameInflectorServiceId = (string) $definition->getArgument(2);
-                   
+
                     return $methodNameInflectorServiceId === 'tactician.handler.method_name_inflector.handle_class_name';
                 })
             );

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -32,6 +32,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -67,6 +71,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -91,6 +99,10 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once();
+
         $this->container->shouldReceive('has')
             ->with('tactician.handler.locator.symfony')
             ->once()
@@ -110,6 +122,47 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ],
                 'service_id_2' => [
                     ['command' => 'my_command']
+                ],
+            ]);
+
+        $definition->shouldReceive('addArgument')
+            ->never();
+
+        $this->compiler->process($this->container);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testProcessAbortsOnInvalidBus()
+    {
+        $definition = \Mockery::mock(Definition::class);
+
+        $this->container->shouldReceive('getExtensionConfig')
+            ->with('tactician')
+            ->once()
+            ->andReturn([
+                'commandbus' => [
+                    'default' => []
+                ]
+            ]);
+
+        $this->container->shouldReceive('has')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn(true);
+
+        $this->container->shouldReceive('findDefinition')
+            ->with('tactician.handler.locator.symfony')
+            ->once()
+            ->andReturn($definition);
+
+        $this->container->shouldReceive('findTaggedServiceIds')
+            ->with('tactician.handler')
+            ->once()
+            ->andReturn([
+                'service_id_1' => [
+                    ['command' => 'my_command', 'bus' => 'bad_bus_name']
                 ],
             ]);
 

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -58,6 +58,9 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 ],
             ]);
 
+        $this->container->shouldReceive('setDefinition')
+            ->twice();
+
         $definition->shouldReceive('addArgument')
             ->once();
 
@@ -142,6 +145,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
+                'default_bus' => 'default',
                 'commandbus' => [
                     'default' => []
                 ]
@@ -180,6 +184,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
             ->with('tactician')
             ->once()
             ->andReturn([
+                'default_bus' => 'default',
                 'commandbus' => [
                     'custom_bus' => []
                 ]
@@ -206,7 +211,7 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('setDefinition')
             ->with(
-                'tactician.handler.locator.symfony.custom_bus',
+                'tactician.commandbus.custom_bus.handler.locator',
                 \Mockery::type('Symfony\Component\DependencyInjection\Definition')
             );
 

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -99,29 +99,6 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('tactician.commandbus.default');
     }
 
-    public function testMethodNameInflectorDefault()
-    {
-        $this->load();
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'tactician.middleware.command_handler',
-            2,
-            new Reference('tactician.handler.method_name_inflector.handle')
-        );
-    }
-
-    public function testMethodNameInflectorNonDefault()
-    {
-        $this->load([
-            'method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name_without_suffix'
-        ]);
-
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'tactician.middleware.command_handler',
-            2,
-            new Reference('tactician.handler.method_name_inflector.handle_class_name_without_suffix')
-        );
-    }
-
     public function testLoadSecurityConfiguration()
     {
         $securitySettings = ['Some\Command' => 'ROLE_USER', 'Some\Other\Command' => 'ROLE_ADMIN'];


### PR DESCRIPTION
Following #20

Just let the check of `tactician.middleware.command_handler` as I'm not sure to get what is wrong with it.

Let me know what we need to go forward.
