### PR TITLE
Fix the mess I introduced ;)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ composer.phar
 composer.lock
 vendor/
 build/
+**/cache/*
+**/logs/*

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -23,9 +23,8 @@ class CommandHandlerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $tacticianConfig = $container->getExtensionConfig('tactician');
-        $defaultBusId = $tacticianConfig['default_bus'];
-        $busIds = array_keys($tacticianConfig['commandbus']);
+        $defaultBusId = $container->getParameter('tactician.commandbus.default');
+        $busIds = $container->getParameter('tactician.commandbus.ids');
         $busIdToHandlerMapping = [];
 
         foreach ($container->findTaggedServiceIds('tactician.handler') as $id => $tags) {
@@ -48,6 +47,7 @@ class CommandHandlerPass implements CompilerPassInterface
 
         foreach ($busIdToHandlerMapping as $busId => $handlerMapping) {
             $locatorServiceId = 'tactician.commandbus.'.$busId.'.handler.locator';
+            $methodInflectorId = $container->getParameter(sprintf('tactician.method_inflector.%s', $busId));
             $container->setDefinition(
                 $locatorServiceId,
                 $this->buildLocatorDefinition($handlerMapping)
@@ -55,7 +55,14 @@ class CommandHandlerPass implements CompilerPassInterface
 
             $container->setDefinition(
                 'tactician.commandbus.'.$busId.'.middleware.command_handler',
-                $this->buildCommandHandlerDefinition($busId, $locatorServiceId, $tacticianConfig)
+                new Definition(
+                    CommandHandlerMiddleware::class,
+                    [
+                        new Reference('tactician.handler.command_name_extractor.class_name'),
+                        new Reference($locatorServiceId),
+                        new Reference($methodInflectorId)
+                    ]
+                )
             );
         }
 
@@ -95,32 +102,5 @@ class CommandHandlerPass implements CompilerPassInterface
                 $handlerMapping,
             ]
         );
-    }
-
-    /**
-     * @param string $busId
-     * @param string $locatorServiceId
-     * @param array $config
-     * @return Definition
-     */
-    protected function buildCommandHandlerDefinition($busId, $locatorServiceId, array $config)
-    {
-        return new Definition(
-            CommandHandlerMiddleware::class,
-            [
-                new Reference('tactician.handler.command_name_extractor.class_name'),
-                new Reference($locatorServiceId),
-                new Reference($this->methodInflectorOfBus($busId, $config))
-            ]
-        );
-    }
-
-    private function methodInflectorOfBus($busId, array $config)
-    {
-        if (array_key_exists('method_inflector', $config['commandbus'][$busId])) {
-            return $config['commandbus'][$busId]['method_inflector'];
-        }
-
-        return $config['method_inflector'];
     }
 }

--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -45,12 +45,15 @@ class CommandHandlerPass implements CompilerPassInterface
             }
         }
 
-        foreach ($busIdToHandlerMapping as $busId => $handlerMapping) {
+        foreach ($busIds as $busId) {
             $locatorServiceId = 'tactician.commandbus.'.$busId.'.handler.locator';
             $methodInflectorId = $container->getParameter(sprintf('tactician.method_inflector.%s', $busId));
             $container->setDefinition(
                 $locatorServiceId,
-                $this->buildLocatorDefinition($handlerMapping)
+                $this->buildLocatorDefinition(
+                    // Build an empty locator if no command defined. To be sure extension still working
+                    array_key_exists($busId, $busIdToHandlerMapping) ? $busIdToHandlerMapping[$busId] : []
+                )
             );
 
             $container->setDefinition(

--- a/DependencyInjection/Compiler/SecurityMiddlewarePass.php
+++ b/DependencyInjection/Compiler/SecurityMiddlewarePass.php
@@ -1,0 +1,30 @@
+<?php
+namespace League\Tactician\Bundle\DependencyInjection\Compiler;
+
+use League\Tactician\Bundle\Middleware\SecurityMiddleware;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass registers security middleware if possible
+ */
+class SecurityMiddlewarePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('security.authorization_checker')) {
+            return;
+        }
+
+        $container->setDefinition(
+            SecurityMiddleware::SERVICE_ID,
+            new Definition(SecurityMiddleware::class, [ new Reference('security.authorization_checker') ])
+        );
+    }
+}
+

--- a/DependencyInjection/Compiler/UnknownMiddleware.php
+++ b/DependencyInjection/Compiler/UnknownMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace League\Tactician\Bundle\DependencyInjection\Compiler;
+
+use League\Tactician\Bundle\Middleware;
+
+class UnknownMiddleware extends \RuntimeException
+{
+    public static function withId($serviceId)
+    {
+        return new static(
+            trim(sprintf('Unknown middleware with service id "%s". %s', $serviceId, static::completeHelpMessage($serviceId)))
+        );
+    }
+
+    private static function completeHelpMessage($serviceId)
+    {
+        $helpMessages = [
+            Middleware\ValidatorMiddleware::SERVICE_ID => 'You should have the symfony validator service enabled to use this middleware.',
+            Middleware\SecurityMiddleware::SERVICE_ID => 'You should have the symfony security service enabled to use this middleware.',
+        ];
+
+        if (array_key_exists($serviceId, $helpMessages)) {
+            return $helpMessages[$serviceId];
+        }
+    }
+}

--- a/DependencyInjection/Compiler/ValidatorMiddlewarePass.php
+++ b/DependencyInjection/Compiler/ValidatorMiddlewarePass.php
@@ -1,0 +1,30 @@
+<?php
+namespace League\Tactician\Bundle\DependencyInjection\Compiler;
+
+use League\Tactician\Bundle\Middleware\ValidatorMiddleware;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass registers validator middleware if possible
+ */
+class ValidatorMiddlewarePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('validator')) {
+            return;
+        }
+
+        $container->setDefinition(
+            ValidatorMiddleware::SERVICE_ID,
+            new Definition(ValidatorMiddleware::class, [ new Reference('validator') ])
+        );
+    }
+}
+

--- a/DependencyInjection/TacticianExtension.php
+++ b/DependencyInjection/TacticianExtension.php
@@ -51,7 +51,15 @@ class TacticianExtension extends ConfigurableExtension
             if ($commandBusName === $mergedConfig['default_bus']) {
                 $container->setAlias('tactician.commandbus', $serviceName);
             }
+            $container->setParameter(
+                sprintf('tactician.method_inflector.%s', $commandBusName),
+                array_key_exists('method_inflector', $commandBusConfig)
+                    ? $commandBusConfig['method_inflector']
+                    : $mergedConfig['method_inflector']
+            );
         }
+        $container->setParameter('tactician.commandbus.default', $mergedConfig['default_bus']);
+        $container->setParameter('tactician.commandbus.ids', array_keys($mergedConfig['commandbus']));
     }
 
     /**

--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -24,12 +24,8 @@ class ContainerBasedHandlerLocator implements HandlerLocator
      * @param ContainerInterface $container
      * @param $commandToServiceIdMapping
      */
-    public function __construct(ContainerInterface $container, $commandToServiceIdMapping)
+    public function __construct(ContainerInterface $container, array $commandToServiceIdMapping)
     {
-        if (empty($commandToServiceIdMapping)) {
-            throw new \InvalidArgumentException('commandToServiceIdMapping cannot be empty');
-        }
-
         $this->container = $container;
         $this->commandToServiceId = $commandToServiceIdMapping;
     }

--- a/Middleware/SecurityMiddleware.php
+++ b/Middleware/SecurityMiddleware.php
@@ -6,9 +6,10 @@ use League\Tactician\Middleware;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-
 class SecurityMiddleware implements Middleware
 {
+    const SERVICE_ID = 'tactician.middleware.security';
+
     /**
      * @var AuthorizationCheckerInterface
      */
@@ -17,7 +18,8 @@ class SecurityMiddleware implements Middleware
     /**
      * @param AuthorizationCheckerInterface $authorizationChecker
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker) {
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+    {
         $this->authorizationChecker = $authorizationChecker;
     }
 
@@ -30,11 +32,11 @@ class SecurityMiddleware implements Middleware
     {
         if ($this->authorizationChecker->isGranted('handle', $command)) {
             return $next($command);
-        } else {
-            throw new AccessDeniedException(
-                sprintf('The current user is not allowed to handle command of type \'%s\'', get_class($command))
-            );
         }
+
+        throw new AccessDeniedException(
+            sprintf('The current user is not allowed to handle command of type \'%s\'', get_class($command))
+        );
     }
 }
 

--- a/Middleware/ValidatorMiddleware.php
+++ b/Middleware/ValidatorMiddleware.php
@@ -7,6 +7,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ValidatorMiddleware implements Middleware
 {
+    const SERVICE_ID = 'tactician.middleware.validator';
+
     /**
      * @var ValidatorInterface
      */
@@ -15,7 +17,8 @@ class ValidatorMiddleware implements Middleware
     /**
      * @param ValidatorInterface | null $validator
      */
-    public function __construct(ValidatorInterface $validator = null) {
+    public function __construct(ValidatorInterface $validator)
+    {
         $this->validator = $validator;
     }
 
@@ -28,13 +31,6 @@ class ValidatorMiddleware implements Middleware
      */
     public function execute($command, callable $next)
     {
-        if ($this->validator === null) {
-            throw new \Exception(
-                "The Validator Middleware requires the Validator service (@validator) to be present and configured." .
-                "Please configure it."
-            );
-        }
-
         $constraintViolations = $this->validator->validate($command);
 
         if (count($constraintViolations) > 0) {

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -5,16 +5,6 @@ services:
     tactician.middleware.locking:
         class: League\Tactician\Plugins\LockingMiddleware
 
-    tactician.middleware.validator:
-        class: League\Tactician\Bundle\Middleware\ValidatorMiddleware
-        arguments:
-            - "@?validator"
-
-    tactician.middleware.security:
-        class: League\Tactician\Bundle\Middleware\SecurityMiddleware
-        arguments:
-            - "@security.authorization_checker"
-
     # The standard Handler method name inflectors
     tactician.handler.method_name_inflector.handle:
         class: League\Tactician\Handler\MethodNameInflector\HandleInflector

--- a/TacticianBundle.php
+++ b/TacticianBundle.php
@@ -1,8 +1,7 @@
 <?php namespace League\Tactician\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
-use League\Tactician\Bundle\DependencyInjection\Compiler\DoctrineMiddlewarePass;
+use League\Tactician\Bundle\DependencyInjection\Compiler;
 use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -11,8 +10,10 @@ class TacticianBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-        $container->addCompilerPass(new DoctrineMiddlewarePass());
-        $container->addCompilerPass(new CommandHandlerPass());
+        $container->addCompilerPass(new Compiler\DoctrineMiddlewarePass());
+        $container->addCompilerPass(new Compiler\ValidatorMiddlewarePass());
+        $container->addCompilerPass(new Compiler\SecurityMiddlewarePass());
+        $container->addCompilerPass(new Compiler\CommandHandlerPass());
     }
 
     public function getContainerExtension()

--- a/Tests/Bundle/BundleTest.php
+++ b/Tests/Bundle/BundleTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests\Bundle;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * To ensure cache is isolated from each test.
+ *
+ * @runTestsInSeparateProcesses
+ */
+class BundleTest extends KernelTestCase
+{
+    protected function setUp()
+    {
+        static::$kernel = static::createKernel();
+        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'tactician-bundle'.DIRECTORY_SEPARATOR.md5(microtime(true) * rand(0, 10000));
+        if (false === is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        static::$kernel->defineCacheDir($dir);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        require_once __DIR__.'/../testapp/AppKernel.php';
+
+        return new \AppKernel('test', true);
+    }
+
+    public function testHandleCommandOnDefaultBus()
+    {
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.command_handler
+EOF
+        );
+        $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
+            ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText'],
+        ]);
+
+        $this->expectOutputString('Hello world');
+        $this->handleCommand('default', \League\Tactician\Bundle\Tests\EchoText::class, ['Hello world']);
+    }
+
+    /**
+     * @expectedException \League\Tactician\Bundle\DependencyInjection\Compiler\UnknownMiddleware
+     */
+    public function testHandleCommandWithInvalidMiddleware()
+    {
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.validator
+            - tactician.middleware.command_handler
+EOF
+        );
+        static::$kernel->boot();
+    }
+
+    public function testHandleCommandOnMiddlewareWithDependencies()
+    {
+        $this->givenConfig('framework', <<<'EOF'
+validation:
+    enabled: true
+EOF
+        );
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.validator
+            - tactician.middleware.command_handler
+EOF
+        );
+        $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
+            ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText'],
+        ]);
+
+        $this->expectOutputString('Hello world');
+        $this->handleCommand('default', \League\Tactician\Bundle\Tests\EchoText::class, ['Hello world']);
+    }
+
+    public function testHandleCommandOnSpecificBus()
+    {
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.command_handler
+    other:
+        middleware:
+            - tactician.commandbus.other.middleware.command_handler
+EOF
+        );
+        $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
+            ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText', 'bus' => 'other'],
+        ]);
+        $this->expectOutputString('Welcome');
+        $this->handleCommand('other', \League\Tactician\Bundle\Tests\EchoText::class, ['Welcome']);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid bus id "other". Valid buses are: default
+     */
+    public function testHandlerOnUnknownBus()
+    {
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.command_handler
+EOF
+        );
+        $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
+            ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText', 'bus' => 'other'],
+        ]);
+        static::$kernel->boot();
+    }
+
+    /**
+     * @expectedException \League\Tactician\Exception\MissingHandlerException
+     */
+    public function testHandleCommandSpecifiedOnAnotherBus()
+    {
+        $this->givenConfig('tactician', <<<'EOF'
+commandbus:
+    default:
+        middleware:
+            - tactician.middleware.command_handler
+    other:
+        middleware:
+            - tactician.commandbus.other.middleware.command_handler
+EOF
+        );
+        $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
+            ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText', 'bus' => 'other'],
+        ]);
+        $this->handleCommand('default', \League\Tactician\Bundle\Tests\EchoText::class, ['Welcome']);
+    }
+
+    protected function givenConfig($namespace, $config)
+    {
+        static::$kernel->loadConfig($namespace, Yaml::parse((string) $config));
+    }
+
+    protected function registerService($serviceId, $className, array $tags)
+    {
+        static::$kernel->addServiceToRegister($serviceId, $className, $tags);
+    }
+
+    protected function handleCommand($busId, $commandClass, array $args)
+    {
+        $class = new \ReflectionClass($commandClass);
+        $command = $class->newInstanceArgs($args);
+
+        static::$kernel->boot();
+        static::$kernel->getContainer()->get('tactician.commandbus.'.$busId)->handle($command);
+    }
+}

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -29,8 +29,6 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcess()
     {
-        $definition = \Mockery::mock(Definition::class);
-
         $this->parametersShouldBe(
             $this->container,
             [
@@ -66,8 +64,6 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessAbortsOnMissingCommandAttribute()
     {
-        $definition = \Mockery::mock(Definition::class);
-
         $this->parametersShouldBe(
             $this->container,
             [
@@ -96,8 +92,6 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessAbortsOnInvalidBus()
     {
-        $definition = \Mockery::mock(Definition::class);
-
         $this->parametersShouldBe(
             $this->container,
             [
@@ -120,8 +114,6 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessAddsLocatorAndHandlerDefinitionForTaggedBuses()
     {
-        $definition = \Mockery::mock(Definition::class);
-
         $this->parametersShouldBe(
             $this->container,
             [
@@ -144,6 +136,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
         $this->busShouldBeCorrectlyRegisteredInContainer(
             $this->container,
+            'default',
+            'tactician.handler.method_name_inflector.handle'
+        );
+
+        $this->busShouldBeCorrectlyRegisteredInContainer(
+            $this->container,
             'custom_bus',
             'tactician.handler.method_name_inflector.handle'
         );
@@ -159,8 +157,6 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessAddsHandlerDefinitionWithNonDefaultMethodNameInflector()
     {
-        $definition = \Mockery::mock(Definition::class);
-
         $this->parametersShouldBe(
             $this->container,
             [
@@ -241,5 +237,13 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
                 $handlerId
             )
             ->once();
+
+        $definition = \Mockery::mock(Definition::class);
+        $definition->shouldReceive('getArgument')->andReturn([]);
+        $this->container->shouldReceive('getDefinition')
+            ->with('tactician.commandbus.'.$busId)
+            ->once()
+            ->andReturn($definition)
+        ;
     }
 }

--- a/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -31,14 +31,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->configShouldBe(
+        $this->parametersShouldBe(
             $this->container,
             [
-                'default_bus' => 'default',
-                'method_inflector' => 'tactician.handler.method_name_inflector.handle',
-                'commandbus' => [
-                    'default' => []
-                ]
+                'tactician.commandbus.default' => 'default',
+                'tactician.method_inflector.default' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.commandbus.ids' => ['default']
             ]
         );
 
@@ -70,11 +68,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->configShouldBe(
+        $this->parametersShouldBe(
             $this->container,
             [
-                'default_bus' => 'default',
-                'commandbus' => []
+                'tactician.commandbus.default' => 'default',
+                'tactician.method_inflector.default' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.commandbus.ids' => ['default']
             ]
         );
 
@@ -99,13 +98,12 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-         $this->configShouldBe(
+        $this->parametersShouldBe(
             $this->container,
             [
-                'default_bus' => 'default',
-                'commandbus' => [
-                    'default' => []
-                ]
+                'tactician.commandbus.default' => 'default',
+                'tactician.method_inflector.default' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.commandbus.ids' => ['default']
             ]
         );
 
@@ -124,16 +122,16 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->configShouldBe(
+        $this->parametersShouldBe(
             $this->container,
             [
-                'default_bus' => 'custom_bus',
-                'method_inflector' => 'tactician.handler.method_name_inflector.handle',
-                'commandbus' => [
-                    'custom_bus' => [],
-                    'other_bus' => [],
-                ]
-            ]);
+                'tactician.commandbus.default' => 'custom_bus',
+                'tactician.method_inflector.default' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.method_inflector.custom_bus' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.method_inflector.other_bus' => 'tactician.handler.method_name_inflector.handle',
+                'tactician.commandbus.ids' => ['default', 'custom_bus', 'other_bus']
+            ]
+        );
 
         $this->servicesTaggedShouldBe(
             $this->container,
@@ -163,15 +161,14 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \Mockery::mock(Definition::class);
 
-        $this->configShouldBe(
+        $this->parametersShouldBe(
             $this->container,
             [
-                'default_bus' => 'custom_bus',
-                'method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name',
-                'commandbus' => [
-                    'custom_bus' => []
-                ]
-            ]);
+                'tactician.commandbus.default' => 'custom_bus',
+                'tactician.method_inflector.custom_bus' => 'tactician.handler.method_name_inflector.handle_class_name',
+                'tactician.commandbus.ids' => ['custom_bus']
+            ]
+        );
 
         $this->servicesTaggedShouldBe(
             $this->container,
@@ -190,44 +187,15 @@ class CommandHandlerPassTest extends \PHPUnit_Framework_TestCase
         $this->compiler->process($this->container);
     }
 
-    public function testProcessAddsHandlerDefinitionWithSpecificMethodInflector()
+    private function parametersShouldBe($container, array $parameters)
     {
-        $definition = \Mockery::mock(Definition::class);
-
-        $this->configShouldBe(
-            $this->container,
-            [
-                'default_bus' => 'custom_bus',
-                'method_inflector' => 'tactician.handler.method_name_inflector.handle',
-                'commandbus' => [
-                    'custom_bus' => ['method_inflector' => 'tactician.handler.method_name_inflector.handle_class_name']
-                ]
-            ]);
-
-        $this->servicesTaggedShouldBe(
-            $this->container,
-            [
-                'service_id_1' => [
-                    ['command' => 'my_command', 'bus' => 'custom_bus']
-                ],
-            ]);
-
-        $this->busShouldBeCorrectlyRegisteredInContainer(
-            $this->container,
-            'custom_bus',
-            'tactician.handler.method_name_inflector.handle_class_name'
-        );
-
-        $this->compiler->process($this->container);
-    }
-
-    private function configShouldBe($container, array $config)
-    {
-        $container->shouldReceive('getExtensionConfig')
-            ->with('tactician')
-            ->once()
-            ->andReturn($config)
-        ;
+        foreach ($parameters as $key => $value) {
+            $container->shouldReceive('getParameter')
+                ->with($key)
+                ->once()
+                ->andReturn($value)
+            ;
+        }
     }
 
     private function servicesTaggedShouldBe($container, array $config)

--- a/Tests/DependencyInjection/TacticianExtensionTest.php
+++ b/Tests/DependencyInjection/TacticianExtensionTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace League\Tactician\Bundle\Tests\DependencyInjection;
-
 
 use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
@@ -60,12 +58,41 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('tactician.commandbus.bus_1');
         $this->assertContainerBuilderHasService('tactician.commandbus.bus_2');
+        $this->assertContainerBuilderHasParameter('tactician.commandbus.ids', ['default', 'bus_1', 'bus_2']);
+        $this->assertContainerBuilderHasParameter('tactician.commandbus.default', 'bus_2');
+        $this->assertContainerBuilderHasParameter('tactician.method_inflector.default', 'tactician.handler.method_name_inflector.handle');
+        $this->assertContainerBuilderHasParameter('tactician.method_inflector.bus_1', 'tactician.handler.method_name_inflector.handle');
+        $this->assertContainerBuilderHasParameter('tactician.method_inflector.bus_2', 'tactician.handler.method_name_inflector.handle');
         $this->assertContainerBuilderHasAlias('tactician.commandbus', 'tactician.commandbus.bus_2');
+    }
+
+    public function testCommandBusLoadsAndSetsCorrectMethodInflector()
+    {
+        $this->load([
+            'commandbus' => [
+                'bus_1' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ],
+                    'method_inflector' => 'my.inflector.service'
+                ],
+                'bus_2' => [
+                    'middleware' => [
+                        'my_middleware.custom.stuff',
+                        'tactician.middleware.command_handler',
+                    ]
+                ],
+            ],
+            'default_bus' => 'bus_2'
+        ]);
+
+        $this->assertContainerBuilderHasParameter('tactician.method_inflector.bus_1', 'my.inflector.service');
+        $this->assertContainerBuilderHasParameter('tactician.method_inflector.bus_2', 'tactician.handler.method_name_inflector.handle');
     }
 
     public function testCommandBusLoadsAndConfigures()
     {
-
         $middlewares = [
             new Reference('my_middleware.custom.stuff'),
             new Reference('tactician.middleware.command_handler')

--- a/Tests/Middleware/ValidatorMiddlewareTest.php
+++ b/Tests/Middleware/ValidatorMiddlewareTest.php
@@ -56,14 +56,4 @@ class ValidatorMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->middleware->execute(new FakeCommand(), function () {
         });
     }
-
-    /**
-     * @expectedException \Exception
-     */
-    public function testExecuteWithoutValidator()
-    {
-        $this->middleware = new ValidatorMiddleware();
-        $this->middleware->execute(new FakeCommand(), function () {
-        });
-    }
 }

--- a/Tests/testapp/AppKernel.php
+++ b/Tests/testapp/AppKernel.php
@@ -1,0 +1,74 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class AppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    private $config = [];
+
+    private $services = [];
+
+    public function registerBundles()
+    {
+        return [
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new League\Tactician\Bundle\TacticianBundle(),
+        ];
+    }
+
+    public function defineCacheDir($dir)
+    {
+        $this->cacheDir = $dir;
+    }
+
+    public function loadConfig($namespace, array $tacticianConfig)
+    {
+        $this->config[$namespace] = $tacticianConfig;
+    }
+
+    public function addServiceToRegister($serviceId, $className, array $tags)
+    {
+        $this->services[$serviceId] = [
+            'className' => $className,
+            'tags' => $tags,
+        ];
+    }
+
+    public function getCacheDir()
+    {
+        return $this->cacheDir;
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
+    {
+        $frameworkConfig = ['secret' => 'S0ME_SECRET'];
+        if (array_key_exists('framework', $this->config)) {
+            $this->config['framework'] = array_merge($frameworkConfig, $this->config['framework']);
+        } else {
+            $this->config['framework'] = $frameworkConfig;
+        }
+
+        foreach ($this->config as $namespace => $config) {
+            $c->loadFromExtension($namespace, $config);
+        }
+
+        foreach ($this->services as $serviceId => $definition) {
+            $service = $c->register($serviceId, $definition['className']);
+            foreach ($definition['tags'] as $tag) {
+                $tagName = $tag['name'];
+                unset($tag['name']);
+                $service->addTag($tagName, $tag);
+            }
+        }
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes)
+    {
+    }
+}

--- a/Tests/testapp/src/EchoText.php
+++ b/Tests/testapp/src/EchoText.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests;
+
+class EchoText
+{
+    private $text;
+
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+}

--- a/Tests/testapp/src/EchoTextHandler.php
+++ b/Tests/testapp/src/EchoTextHandler.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests;
+
+class EchoTextHandler
+{
+    public function handle(EchoText $command)
+    {
+        echo $command->getText();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,11 @@
       "League\\Tactician\\Bundle\\" : ""
     }
   },
+  "autoload-dev" : {
+    "psr-4" : {
+      "League\\Tactician\\Bundle\\Tests\\" : "Tests/testapp/src"
+    }
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
@@ -59,6 +64,8 @@
     "matthiasnoback/symfony-dependency-injection-test": "^0.7",
     "symfony/security": "^2.8|^3.1",
     "symfony/validator": "^2.8|^3.0",
-    "league/tactician-doctrine": "^1.0"
+    "league/tactician-doctrine": "^1.0",
+    "symfony/framework-bundle": "^2.8|^3.0",
+    "doctrine/annotations": "^1.2"
   }
 }


### PR DESCRIPTION
getExtensionConfig is in fact not the processed config.
So we do the same that Symfony, parsing config and put expected result in parameter