### PR TITLE
Allow command handlers to be private

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
   "require" : {
     "php":  ">=7.0",
     "league/tactician": "^1.0",
+    "league/tactician-container": "^2.0",
     "symfony/config": "^2.8|^3.0",
     "symfony/dependency-injection": "^2.8|^3.0",
     "symfony/http-kernel": "^2.8|^3.0",

--- a/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -3,10 +3,13 @@
 namespace League\Tactician\Bundle\Tests\DependencyInjection\Compiler;
 
 use League\Tactician\Bundle\DependencyInjection\Compiler\CommandHandlerPass;
+use League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator;
+use League\Tactician\Container\ContainerLocator;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class CommandHandlerPassTest extends TestCase
 {
@@ -212,7 +215,10 @@ class CommandHandlerPassTest extends TestCase
         $container->shouldReceive('setDefinition')
             ->with(
                 $handlerLocatorId,
-                \Mockery::type('Symfony\Component\DependencyInjection\Definition')
+                $this->callback(function ($definition) {
+                    $this->assertInstanceOf(Definition::class, $definition);
+                    $this->assertSame(class_exists(ServiceLocator::class) ? ContainerLocator::class : ContainerBasedHandlerLocator::class, $definition->getClass());
+                })
             );
 
         $this->container->shouldReceive('setDefinition')


### PR DESCRIPTION
As promised in https://github.com/thephpleague/tactician/pull/111. 

This PR allows for private command handlers, leveraging the `tactician/container` PSR-11 implementation, allowing us to stop injecting the whole DIC. 
It works on symfony 3.3+ (current behavior still works for previous symfony versions).
A colleague already uses it in an enterprise project and is quite happy with it.

(Travis build might not be green right now due to packagist network issues)