### PR TITLE
Enriches the README with Symfony 3.3 specific config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ foo.user.register_user_handler:
         - { name: tactician.handler, command: Foo\User\RegisterUserCommand }
 ```
 
+### Symfony 3.3+
+As of Symfony version 3.3 all services registered in the DI container are marked private by default. For this bundle to work properly the registered handlers needs to be public. This can be achieved by setting the public attribute on the service to `true`. The example of above becomes:
+
+```yaml
+foo.user.register_user_handler:
+    class: Foo\User\RegisterUserHandler
+    public: true
+    arguments:
+        - '@foo.user.user_repository'
+    tags:
+        - { name: tactician.handler, command: Foo\User\RegisterUserCommand }
+```
+
 ## Configuring Middleware
 Everything inside Tactician is a middleware plugin. Without any middleware configured, nothing will happen when you pass a command to `handle()`.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ foo.user.register_user_handler:
 ```
 
 ### Symfony 3.3+
-As of Symfony version 3.3 all services registered in the DI container are marked private by default. For this bundle to work properly the registered handlers needs to be public. This can be achieved by setting the public attribute on the service to `true`. The example of above becomes:
+As of Symfony version 3.3 all services registered in the DI container are marked private by default. For this bundle to work properly the registered handlers needs to be public. This can be achieved by setting the public attribute on the service to `true`. 
+
+*Note:* This is a temporary solution until version 1.0 of the bundle is released. In this release it won't be necessary anymore to register the command handlers publicly.
+
+The example of above becomes:
 
 ```yaml
 foo.user.register_user_handler:


### PR DESCRIPTION
I might be adding the obvious, but it costed me two hours to figure it out. 

In order to make this bundle work registered services needs to be marked public. I've added an example to the README.