### PR TITLE
Disallow constructor as result in TypeHintMapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ This detects what commands this handler receives by inspecting the class' method
 
 1. The method must be public.
 2. The method must accept only one parameter.
-3. The parameter must be typehinted with a class name.
+3. The method must not be the constructor.
+4. The parameter must be typehinted with a class name.
 
 In other words, the RegisterUserHandler class should look like this:
 

--- a/src/DependencyInjection/HandlerMapping/TypeHintMapping.php
+++ b/src/DependencyInjection/HandlerMapping/TypeHintMapping.php
@@ -39,7 +39,7 @@ final class TypeHintMapping extends TagBasedMapping
 
         $reflClass = new ReflectionClass($definition->getClass());
 
-        foreach($reflClass->getMethods() as $method) {
+        foreach ($reflClass->getMethods() as $method) {
             if (!$method->isPublic()) {
                 continue;
             }
@@ -48,8 +48,12 @@ final class TypeHintMapping extends TagBasedMapping
                 continue;
             }
 
+            if ($method->isConstructor()) {
+                continue;
+            }
+
             $parameter = $method->getParameters()[0];
-            if(!$parameter->hasType() || $parameter->getType()->isBuiltin()) {
+            if (!$parameter->hasType() || $parameter->getType()->isBuiltin()) {
                 continue;
             }
 

--- a/tests/DependencyInjection/HandlerMapping/TypeHintMappingTest.php
+++ b/tests/DependencyInjection/HandlerMapping/TypeHintMappingTest.php
@@ -59,7 +59,8 @@ final class TypeHintMappingTest extends TestCase
             ],
             'will skip methods with no typehint' => [NoTypehintHandler::class, []],
             'will not try to map scalar typehints' => [ScalarHandler::class, []],
-            'will not use protected or private methods' => [ProtectedMethodHandler::class, []]
+            'will not use protected or private methods' => [ProtectedMethodHandler::class, []],
+            'will not use constructor method' => [ConstructorHandler::class, []]
         ];
     }
 
@@ -182,4 +183,15 @@ class ProtectedMethodHandler
     private function execute(OtherFakeCommand $command)
     {
     }
+}
+
+class ConstructorHandler
+{
+    public function __construct(SomeDependency $dependency)
+    {
+    }
+}
+
+class SomeDependency
+{
 }


### PR DESCRIPTION
I tested the new TypeHintMapping in my project and found a problem when the constructor matches the criteria for the mapper (public, one parameter, type hinted).
In the end I got an `InvalidArgumentException` from `Routing::assertValidCommandFQCN()` as I type hinted an interface. This interface slips through in the `$result` array because of the constructor, but the assertion fails as it does not pass the `class_exists` check.

If this is in fact an unwanted behaviour, I added a test which reproduces the error and added a check to disallow the constructor.