### PR TITLE
Drop support for outdated symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ env:
     - DOCTRINE="true"
     - DOCTRINE="false"
     - SYMFONY_VERSION="2.8.*"
-    - SYMFONY_VERSION="3.0.*"
-    - SYMFONY_VERSION="3.2.*"
     - SYMFONY_VERSION="3.3.*"
+    - SYMFONY_VERSION="3.4.*"
 
 matrix:
   include:
@@ -25,6 +24,10 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"
+    - php: 7.1
+      env: SYMFONY_VERSION="4.0.*"
+  allow_failures:
+    - env: SYMFONY_VERSION="4.0.*"
 
 before_install:
   - composer self-update || true

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     "php":  ">=7.0",
     "league/tactician": "^1.0",
     "league/tactician-container": "^2.0",
-    "symfony/config": "^2.8|^3.0",
-    "symfony/dependency-injection": "^2.8|^3.0",
-    "symfony/http-kernel": "^2.8|^3.0",
-    "symfony/yaml": "^2.8|^3.0"
+    "symfony/config": "^2.8|^3.3",
+    "symfony/dependency-injection": "^2.8|^3.3",
+    "symfony/http-kernel": "^2.8|^3.3",
+    "symfony/yaml": "^2.8|^3.3"
   },
   "minimum-stability": "beta",
   "suggest": {


### PR DESCRIPTION
Symfony 3.0, 3.1 and 3.2 are not maintained (see http://symfony.com/roadmap), they don't get bug fixes anymore. I think the next minor version of this bundle should not support them, that is fine regarding semver.
As a bonus, I propose to add 3.4 (must be green) and 4.0 (failure allowed) to travis.