### PR TITLE
Make symfony/console a soft dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
     "symfony/config": "^2.8|^3.3",
     "symfony/dependency-injection": "^2.8|^3.3",
     "symfony/http-kernel": "^2.8|^3.3",
-    "symfony/yaml": "^2.8|^3.3",
-    "symfony/console": "^2.8|^3.3"
+    "symfony/yaml": "^2.8|^3.3"
   },
   "minimum-stability": "beta",
   "suggest": {
+    "symfony/console": "For debugging command-to-handler routing using the tactician:debug console command",
     "symfony/validator": "For command validator middleware",
     "symfony/security": "For command security middleware",
     "league/tactician-doctrine": "For doctrine transaction middleware"
@@ -62,6 +62,7 @@
   "require-dev": {
     "phpunit/phpunit": "~6.1",
     "mockery/mockery": "~0.9.9",
+    "symfony/console": "^2.8|^3.3",
     "symfony/security": "^2.8|^3.0",
     "symfony/validator": "^2.8|^3.0",
     "league/tactician-doctrine": "^1.1",


### PR DESCRIPTION
Like validator and security, the bundle can be used without console. Especially relevant with flex which does not ship symfony/symfony.