### PR TITLE
Make CommandHandlerPass using the real merged config

### DIFF
--- a/src/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/src/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -24,7 +24,9 @@ class CommandHandlerPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        $builders = BusBuildersFromConfig::convert($container->getExtensionConfig('tactician')[0]);
+        $builders = BusBuildersFromConfig::convert(
+            $this->readAndForgetParameter($container, 'tactician.merged_config')
+        );
 
         $routing = $this->handlerMapping->build($container, $builders->createBlankRouting());
 
@@ -46,5 +48,13 @@ class CommandHandlerPass implements CompilerPassInterface
         if ($container->hasDefinition('tactician.command.debug')) {
             $container->getDefinition('tactician.command.debug')->addArgument($mappings);
         }
+    }
+
+    private function readAndForgetParameter(ContainerBuilder $container, $parameter)
+    {
+        $value = $container->getParameter($parameter);
+        $container->getParameterBag()->remove($parameter);
+
+        return $value;
     }
 }

--- a/src/DependencyInjection/TacticianExtension.php
+++ b/src/DependencyInjection/TacticianExtension.php
@@ -22,7 +22,7 @@ class TacticianExtension extends ConfigurableExtension
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config/services'));
         $loader->load('services.yml');
-
+        $container->setParameter('tactician.merged_config', $mergedConfig);
         $this->configureSecurity($mergedConfig, $container);
     }
 

--- a/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -159,7 +159,7 @@ class CommandHandlerPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->prependExtensionConfig('tactician', $config);
+        $container->setParameter('tactician.merged_config', $config);
 
         return $container;
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -27,6 +27,19 @@ class ConfigurationTest extends TestCase
         $this->assertConfigurationIsValid([]);
     }
 
+    public function testDefaultConfiguration()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [],
+            [
+                'commandbus' => ['default' => ['middleware' => ['tactician.middleware.command_handler']]],
+                'default_bus' => 'default',
+                'method_inflector' => 'tactician.handler.method_name_inflector.handle',
+                'security' => [],
+            ]
+        );
+    }
+
     public function testSimpleMiddleware()
     {
         $this->assertConfigurationIsValid([

--- a/tests/Integration/BasicCommandAndBusMappingTest.php
+++ b/tests/Integration/BasicCommandAndBusMappingTest.php
@@ -11,13 +11,6 @@ class BasicCommandAndBusMappingTest extends IntegrationTest
 {
     public function testHandleCommandOnDefaultBus()
     {
-        $this->givenConfig('tactician', <<<'EOF'
-commandbus:
-    default:
-        middleware:
-            - tactician.middleware.command_handler
-EOF
-        );
         $this->registerService('tactician.test.handler', \League\Tactician\Bundle\Tests\EchoTextHandler::class, [
             ['name' => 'tactician.handler', 'command' => 'League\Tactician\Bundle\Tests\EchoText'],
         ]);


### PR DESCRIPTION
**Problem**
Because `container->getExtensionConfig()` does not return merged config.

**Solution**
Use a temporary dic parameter to transport the merged config to the CommandHandlerPass.

Fix #80 