### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,10 @@
     "php":  ">=7.0",
     "league/tactician": "^1.0",
     "league/tactician-container": "^2.0",
-    "symfony/config": "^2.8|^3.3",
-    "symfony/dependency-injection": "^2.8|^3.3",
-    "symfony/http-kernel": "^2.8|^3.3",
-    "symfony/yaml": "^2.8|^3.3"
+    "symfony/config": "^2.8|^3.3|^4.0",
+    "symfony/dependency-injection": "^2.8|^3.3|^4.0",
+    "symfony/http-kernel": "^2.8|^3.3|^4.0",
+    "symfony/yaml": "^2.8|^3.3|^4.0"
   },
   "minimum-stability": "beta",
   "suggest": {
@@ -62,12 +62,12 @@
   "require-dev": {
     "phpunit/phpunit": "~6.1",
     "mockery/mockery": "~1.0",
-    "symfony/console": "^2.8|^3.3",
-    "symfony/security": "^2.8|^3.0",
-    "symfony/validator": "^2.8|^3.0",
+    "symfony/console": "^2.8|^3.3|^4.0",
+    "symfony/security": "^2.8|^3.3|^4.0",
+    "symfony/validator": "^2.8|^3.3|^4.0",
     "league/tactician-doctrine": "^1.1",
-    "symfony/framework-bundle": "^2.8.15|^3.3",
-    "symfony/security-bundle": "^2.8|^3.0",
+    "symfony/framework-bundle": "^2.8.15|^3.3|^4.0",
+    "symfony/security-bundle": "^2.8|^3.3|^4.0",
     "matthiasnoback/symfony-config-test": "^3.0",
     "matthiasnoback/symfony-dependency-injection-test": "^2.1"
   }


### PR DESCRIPTION
This is the continuation of #77 which dropped unmaintained versions of Symfony and aimed to support Symfony 4 too (#78 was closed in favor of it), but constraints for sf 4.0 are actually missing from the patch.