### PR TITLE
Add support for logger middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ If the command fails, it will throw a [League\Tactician\Bundle\Middleware\Invali
 
 This middleware is bundled in Tactician, please refer to [the official documentation](http://tactician.thephpleague.com/plugins/locking-middleware/) for details.
 
+### Logger Middleware (tactician.middleware.logger)
+
+This middleware is bundled in Tactician, please refer to [the official documentation](http://tactician.thephpleague.com/plugins/logger/) for details.
+
 ### Security Middleware (tactician.middleware.security)
 
 The security middleware will perform authorization on handling all commands. By default an AccessDenied exception will be thrown if the user is not authorized.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     "symfony/console": "For debugging command-to-handler routing using the tactician:debug console command",
     "symfony/validator": "For command validator middleware",
     "symfony/security": "For command security middleware",
-    "league/tactician-doctrine": "For doctrine transaction middleware"
+    "league/tactician-doctrine": "For doctrine transaction middleware",
+    "league/tactician-logger": "For logger middleware"
   },
   "autoload" : {
     "psr-4" : {
@@ -66,6 +67,7 @@
     "symfony/security": "^2.8|^3.3|^4.0",
     "symfony/validator": "^2.8|^3.3|^4.0",
     "league/tactician-doctrine": "^1.1",
+    "league/tactician-logger": "^0.10.0",
     "symfony/framework-bundle": "^2.8.15|^3.3|^4.0",
     "symfony/security-bundle": "^2.8|^3.3|^4.0",
     "matthiasnoback/symfony-config-test": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
   "require" : {
     "php":  ">=7.0",
     "league/tactician": "^1.0",
+    "league/tactician-logger": "^0.10.0",
     "league/tactician-container": "^2.0",
     "symfony/config": "^2.8|^3.3|^4.0",
     "symfony/dependency-injection": "^2.8|^3.3|^4.0",
@@ -42,8 +43,7 @@
     "symfony/console": "For debugging command-to-handler routing using the tactician:debug console command",
     "symfony/validator": "For command validator middleware",
     "symfony/security": "For command security middleware",
-    "league/tactician-doctrine": "For doctrine transaction middleware",
-    "league/tactician-logger": "For logger middleware"
+    "league/tactician-doctrine": "For doctrine transaction middleware"
   },
   "autoload" : {
     "psr-4" : {
@@ -67,7 +67,6 @@
     "symfony/security": "^2.8|^3.3|^4.0",
     "symfony/validator": "^2.8|^3.3|^4.0",
     "league/tactician-doctrine": "^1.1",
-    "league/tactician-logger": "^0.10.0",
     "symfony/framework-bundle": "^2.8.15|^3.3|^4.0",
     "symfony/security-bundle": "^2.8|^3.3|^4.0",
     "matthiasnoback/symfony-config-test": "^3.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -68,6 +68,10 @@ class Configuration implements ConfigurationInterface
                         ->prototype('scalar')->end()
                     ->end()
                 ->end()
+                ->scalarNode('logger_formatter')
+                    ->defaultValue('tactician.logger.class_properties_formatter')
+                    ->cannotBeEmpty()
+                ->end()
             ->end()
             ->validate()
                 ->ifTrue(function ($config) {

--- a/src/DependencyInjection/TacticianExtension.php
+++ b/src/DependencyInjection/TacticianExtension.php
@@ -3,6 +3,9 @@
 namespace League\Tactician\Bundle\DependencyInjection;
 
 use League\Tactician\Bundle\Security\Voter\HandleCommandVoter;
+use League\Tactician\Logger\Formatter\ClassNameFormatter;
+use League\Tactician\Logger\Formatter\ClassPropertiesFormatter;
+use League\Tactician\Logger\LoggerMiddleware;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,6 +27,7 @@ class TacticianExtension extends ConfigurableExtension
         $loader->load('services.yml');
         $container->setParameter('tactician.merged_config', $mergedConfig);
         $this->configureSecurity($mergedConfig, $container);
+        $this->configureLogger($mergedConfig, $container);
     }
 
     public function getAlias()
@@ -65,5 +69,43 @@ class TacticianExtension extends ConfigurableExtension
             $definition->addTag('security.voter');
             $container->setDefinition('tactician.middleware.security_voter', $definition);
         }
+    }
+
+    /**
+     * Configure the logger middleware.
+     *
+     * @param array $mergedConfig
+     * @param ContainerBuilder $container
+     */
+    private function configureLogger(array $mergedConfig, ContainerBuilder $container)
+    {
+        if (!class_exists(LoggerMiddleware::class) || !$container->hasDefinition('logger')) {
+            return;
+        }
+
+        $this->configureLoggerFormatters($container);
+
+        $loggerMiddleware = new Definition(LoggerMiddleware::class, [
+            new Reference($mergedConfig['logger_formatter']),
+            new Reference('logger')
+        ]);
+        $loggerMiddleware->setPublic(false);
+        $loggerMiddleware->addTag('monolog.logger', ['channel' => 'command_bus']);
+
+        $container->setDefinition('tactician.middleware.logger', $loggerMiddleware);
+    }
+
+
+    private function configureLoggerFormatters(ContainerBuilder $container)
+    {
+        $container->setDefinition(
+            'tactician.logger.class_properties_formatter',
+            new Definition(ClassPropertiesFormatter::class)
+        )->setPublic(false);
+
+        $container->setDefinition(
+            'tactician.logger.class_name_formatter',
+            new Definition(ClassNameFormatter::class)
+        )->setPublic(false);
     }
 }

--- a/src/DependencyInjection/TacticianExtension.php
+++ b/src/DependencyInjection/TacticianExtension.php
@@ -79,7 +79,7 @@ class TacticianExtension extends ConfigurableExtension
      */
     private function configureLogger(array $mergedConfig, ContainerBuilder $container)
     {
-        if (!class_exists(LoggerMiddleware::class) || !$container->hasDefinition('logger')) {
+        if (!class_exists(LoggerMiddleware::class)) {
             return;
         }
 

--- a/src/DependencyInjection/TacticianExtension.php
+++ b/src/DependencyInjection/TacticianExtension.php
@@ -79,10 +79,6 @@ class TacticianExtension extends ConfigurableExtension
      */
     private function configureLogger(array $mergedConfig, ContainerBuilder $container)
     {
-        if (!class_exists(LoggerMiddleware::class)) {
-            return;
-        }
-
         $this->configureLoggerFormatters($container);
 
         $loggerMiddleware = new Definition(LoggerMiddleware::class, [

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends TestCase
                 'default_bus' => 'default',
                 'method_inflector' => 'tactician.handler.method_name_inflector.handle',
                 'security' => [],
+                'logger_formatter' => 'tactician.logger.class_properties_formatter'
             ]
         );
     }
@@ -238,5 +239,30 @@ class ConfigurationTest extends TestCase
                 ]
             ]
         ]);
+    }
+
+    public function testCustomLoggerFormatterCanBeSet()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                'tactician' => [
+                    'logger_formatter' => 'some.formatter.service',
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'my_middleware.custom.other_stuff',
+                            ],
+                        ],
+                        'second' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'my_middleware.custom.other_stuff',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
     }
 }

--- a/tests/DependencyInjection/TacticianExtensionTest.php
+++ b/tests/DependencyInjection/TacticianExtensionTest.php
@@ -68,7 +68,6 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
 
     public function testLoggerMiddlewareIsCreated()
     {
-        $this->container->setDefinition('logger', new Definition(\stdClass::class));
         $this->load();
 
         $this->assertContainerBuilderHasService('tactician.middleware.logger');

--- a/tests/DependencyInjection/TacticianExtensionTest.php
+++ b/tests/DependencyInjection/TacticianExtensionTest.php
@@ -4,6 +4,7 @@ namespace League\Tactician\Bundle\Tests\DependencyInjection;
 
 use League\Tactician\Bundle\DependencyInjection\TacticianExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class TacticianExtensionTest extends AbstractExtensionTestCase
@@ -63,5 +64,24 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->load();
 
         $this->assertContainerBuilderNotHasService('tactician.middleware.security_voter');
+    }
+
+    public function testLoggerMiddlewareIsCreated()
+    {
+        $this->container->setDefinition('logger', new Definition(\stdClass::class));
+        $this->load();
+
+        $this->assertContainerBuilderHasService('tactician.middleware.logger');
+        $this->assertContainerBuilderHasService('tactician.logger.class_properties_formatter');
+        $this->assertContainerBuilderHasService('tactician.logger.class_name_formatter');
+    }
+
+    public function testLoggerMiddlewareIsNotCreatedWithoutLoggerDefinition()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderNotHasService('tactician.middleware.logger');
+        $this->assertContainerBuilderNotHasService('tactician.logger.class_properties_formatter');
+        $this->assertContainerBuilderNotHasService('tactician.logger.class_name_formatter');
     }
 }

--- a/tests/DependencyInjection/TacticianExtensionTest.php
+++ b/tests/DependencyInjection/TacticianExtensionTest.php
@@ -75,13 +75,4 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('tactician.logger.class_properties_formatter');
         $this->assertContainerBuilderHasService('tactician.logger.class_name_formatter');
     }
-
-    public function testLoggerMiddlewareIsNotCreatedWithoutLoggerDefinition()
-    {
-        $this->load();
-
-        $this->assertContainerBuilderNotHasService('tactician.middleware.logger');
-        $this->assertContainerBuilderNotHasService('tactician.logger.class_properties_formatter');
-        $this->assertContainerBuilderNotHasService('tactician.logger.class_name_formatter');
-    }
 }


### PR DESCRIPTION
It would be nice to use Logger Middleware as well (`tactician.middleware.logger`). The dependency from Logger Middleware is not mandatory.