### PR TITLE
Documents BC break on handler middleware config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Other:
 
 BC Breaks:
 - PHP 7 is now required
+- `tactician.middleware.command_handler` now only contains the default bus handlers. Check [#83](https://github.com/thephpleague/tactician-bundle/pull/83/files) to see how to update your config accordingly.
 
 New features:
 - Allow multiple command buses, each with separated handlers and different method inflectors


### PR DESCRIPTION
Upgrading to 1.0+ broke our config because of the new per-bus command handler middleware setup.
It was already [updated in the readme](https://github.com/thephpleague/tactician-bundle/pull/83/files), but not listed as a BC break.
This lists it as a BC break on the changelog. 