### PR TITLE
Added alias to allow autowiring of default commandbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ class YourNameController
 }
 ```
 
+### Autowiring
+
+If Symfony autowire feature is enabled (avaliable for Symfony 2.8+), instead of creating a service for each controller using the default commandbus you can inject and use it as follows:
+
+```php
+<?php namespace AppBundle\Controller;
+
+use League\Tactician\CommandBus;
+use AppBundle\Commands\DoSomethingCommand;
+
+class YourNameController
+{
+    public function doSomething(CommandBus $commandBus)
+    {
+        $command = new DoSomethingCommand();
+        $commandBus->handle($command);
+    }
+}
+```
+
+Note that this only works for the default commandbus, if you want to inject other than the default one you can override the config through an alias with:
+
+```yaml
+services:
+    League\Tactician\CommandBus: '@tactician.commandbus.your_commandbus'
+```
+
 ## Configuring Command Handlers
 When you pass a command to Tactician, the ultimate goal is to have it mapped to a Handler.
 

--- a/src/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/src/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -6,6 +6,7 @@ use League\Tactician\Bundle\DependencyInjection\Compiler\BusBuilder\BusBuildersF
 use League\Tactician\Bundle\DependencyInjection\HandlerMapping\HandlerMapping;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use League\Tactician\CommandBus;
 
 /**
  * This compiler pass maps Handler DI tags to specific commands.
@@ -41,6 +42,7 @@ class CommandHandlerPass implements CompilerPassInterface
 
         // Setup default aliases
         $container->setAlias('tactician.commandbus', $builders->defaultBus()->serviceId());
+        $container->setAlias(CommandBus::class, 'tactician.commandbus');
         $container->setAlias('tactician.handler.locator.symfony', $builders->defaultBus()->locatorServiceId());
         $container->setAlias('tactician.middleware.command_handler', $builders->defaultBus()->commandHandlerMiddlewareId());
 


### PR DESCRIPTION
As Symfony 3.4+ enables autowiring by default, it would be a good idea to autowire the default command bus (just an alias required) to allow use it as follows

```php
<?php 

namespace AppBundle\Controller;

use League\Tactician\CommandBus;
use AppBundle\Commands\DoSomethingCommand;

class YourNameController
{
    public function doSomething(CommandBus $commandBus)
    {
        $command = new DoSomethingCommand();
        $commandBus->handle($command);
    }
}
```
What do you think?