### PR TITLE
Test against PHP 7.3+ and Symfony 4.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - nightly
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ matrix:
   exclude:
     - php: 7.0
       env: SYMFONY_VERSION="4.0.*"
-
+    - php: 7.0
+      env: SYMFONY_VERSION="4.1.*"
+    - php: 7.0
+      env: SYMFONY_VERSION="4.2.*"
 
 before_install:
   - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     - SYMFONY_VERSION="3.3.*"
     - SYMFONY_VERSION="3.4.*"
     - SYMFONY_VERSION="4.0.*"
+    - SYMFONY_VERSION="4.1.*"
+    - SYMFONY_VERSION="4.2.*"
 
 matrix:
   include:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
             <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <server name="SHELL_VERBOSITY" value="-1"/>
+    </php>
     <filter>
         <whitelist>
             <directory suffix=".php">src/</directory>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,8 +21,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tactician');
+        $treeBuilder = new TreeBuilder('tactician');
+
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('tactician');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
This PR add new test cases to CI, this will cover new versions of PHP and Symfony. As a bonus there is a fix for Symfony deprecation in 4.2, fixed same way as in https://github.com/doctrine/DoctrineBundle/pull/853.

BTW Symfony 3.3 is not supported anymore, maybe it is time to drop support for it?