### PR TITLE
Remove PHP8 deprecation notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,38 +7,23 @@ cache:
     - "$HOME/.composer/cache"
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   matrix:
-    - DOCTRINE="true"
-    - DOCTRINE="false"
-    - SYMFONY_VERSION="2.8.*"
-    - SYMFONY_VERSION="3.3.*"
     - SYMFONY_VERSION="3.4.*"
-    - SYMFONY_VERSION="4.0.*"
-    - SYMFONY_VERSION="4.1.*"
-    - SYMFONY_VERSION="4.2.*"
+    - SYMFONY_VERSION="4.4.*"
+    - SYMFONY_VERSION="5.2.*"
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-    - php: 7.0
+    - php: 7.2
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" DOCTRINE="false"
-  exclude:
-    - php: 7.0
-      env: SYMFONY_VERSION="4.0.*"
-    - php: 7.0
-      env: SYMFONY_VERSION="4.1.*"
-    - php: 7.0
-      env: SYMFONY_VERSION="4.2.*"
-    - php: 7.4
-      env: SYMFONY_VERSION="4.1.*"
 
 before_install:
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0
+- #125 - PHP 8.0 compatibility fixes
+
 ## 1.2.0
 - #121 - Multiple buses can now be autowired based on the parameter name 
 

--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
     "MIT"
   ],
   "require" : {
-    "php":  ">=7.0",
+    "php":  ">=7.2",
     "league/tactician": "^1.0",
     "league/tactician-logger": "^0.10.0",
     "league/tactician-container": "^2.0",
-    "symfony/config": "^2.8|^3.3|^4.0|^5.0",
-    "symfony/dependency-injection": "^2.8|^3.3|^4.0|^5.0",
-    "symfony/http-kernel": "^2.8|^3.3|^4.0|^5.0",
-    "symfony/yaml": "^2.8|^3.3|^4.0|^5.0"
+    "symfony/config": "^3.4|^4.4|^5.0",
+    "symfony/dependency-injection": "^3.4|^4.4|^5.0",
+    "symfony/http-kernel": "^3.4|^4.4|^5.0",
+    "symfony/yaml": "^3.4|^4.4|^5.0"
   },
   "minimum-stability": "beta",
   "suggest": {
@@ -61,15 +61,14 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.1",
+    "phpunit/phpunit": "~8.5",
     "mockery/mockery": "~1.0",
-    "symfony/console": "^2.8|^3.3|^4.0|^5.0",
-    "symfony/security": "^2.8|^3.3|^4.0|^5.0",
-    "symfony/validator": "^2.8|^3.3|^4.0|^5.0",
-    "league/tactician-doctrine": "^1.1.1",
-    "symfony/framework-bundle": "^2.8.15|^3.3|^4.0|^5.0",
-    "symfony/security-bundle": "^2.8|^3.3|^4.0|^5.0",
-    "matthiasnoback/symfony-config-test": "^3.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^2.1"
+    "symfony/console": "^3.4|^4.4|^5.0",
+    "symfony/security-core": "^3.4|^4.4|^5.0",
+    "symfony/validator": "^3.4|^4.4|^5.0",
+    "symfony/framework-bundle": "^3.4.31|^4.4|^5.0",
+    "symfony/security-bundle": "^3.4|^4.4|^5.0",
+    "matthiasnoback/symfony-config-test": "^4.2.1",
+    "matthiasnoback/symfony-dependency-injection-test": "^4.2.1"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,7 +30,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -44,6 +44,8 @@ class DebugCommand extends Command
                 $io->warning("No registered commands for bus $busId");
             }
         }
+
+        return 0;
     }
 
     private function mappingToRows(array $map)

--- a/src/DependencyInjection/HandlerMapping/TypeHintMapping.php
+++ b/src/DependencyInjection/HandlerMapping/TypeHintMapping.php
@@ -57,8 +57,9 @@ final class TypeHintMapping extends TagBasedMapping
 
             $parameter = $method->getParameters()[0];
             if (!$parameter->hasType()
+                || $parameter->getType() instanceof \ReflectionUnionType
                 || $parameter->getType()->isBuiltin()
-                || $parameter->getClass()->isInterface()
+                || (new ReflectionClass($parameter->getType()->getName()))->isInterface()
             ) {
                 continue;
             }

--- a/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
+++ b/tests/DependencyInjection/Compiler/CommandHandlerPassTest.php
@@ -20,7 +20,7 @@ class CommandHandlerPassTest extends TestCase
      */
     private $mappingStrategy;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mappingStrategy = new ClassNameMapping();
     }

--- a/tests/DependencyInjection/Compiler/DoctrineMiddlewarePassTest.php
+++ b/tests/DependencyInjection/Compiler/DoctrineMiddlewarePassTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DoctrineMiddlewarePassTest extends AbstractCompilerPassTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class DoctrineMiddlewarePassTest extends AbstractCompilerPassTestCase
         $this->container->set('doctrine.orm.second_entity_manager', new stdClass());
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new DoctrineMiddlewarePass());
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -72,7 +72,9 @@ class ConfigurationTest extends TestCase
                     ]
                 ]
             ],
-            'Invalid type for path "tactician.commandbus.default.middleware.my_middleware". Expected scalar, but got array.'
+            //we use a regexp to support the slightly different message thrown by symfony >=5.0
+            '#Invalid type for path "tactician.commandbus.default.middleware.my_middleware"\. Expected "?scalar"?, but got "?array"?\.#',
+            true
         );
     }
 

--- a/tests/DependencyInjection/HandlerMapping/RoutingTest.php
+++ b/tests/DependencyInjection/HandlerMapping/RoutingTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 namespace League\Tactician\Bundle\Tests\DependencyInjection\HandlerMapping;
 
 use League\Tactician\Bundle\DependencyInjection\HandlerMapping\Routing;
+use League\Tactician\Bundle\DependencyInjection\InvalidCommandBusId;
 use League\Tactician\Bundle\Tests\Fake\FakeCommand;
 use League\Tactician\Bundle\Tests\Fake\OtherFakeCommand;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 final class RoutingTest extends TestCase
 {
@@ -42,32 +44,29 @@ final class RoutingTest extends TestCase
         $this->assertEquals([FakeCommand::class => 'very.broad.handler'], $routing->commandToServiceMapping('bus2'));
     }
 
-    /**
-     * @expectedException        \League\Tactician\Bundle\DependencyInjection\InvalidCommandBusId
-     * @expectedExceptionMessage Could not find a command bus with id 'fake_bus'. Valid buses are: default
-     */
     public function test_can_not_get_mapping_for_unknown_bus()
     {
+        $this->expectException(InvalidCommandBusId::class);
+        $this->expectExceptionMessage('Could not find a command bus with id \'fake_bus\'. Valid buses are: default');
+
         $routing = new Routing(['default']);
         $routing->commandToServiceMapping('fake_bus');
     }
 
-    /**
-     * @expectedException        \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Can not route Legit\Class to some.handler.service, class Legit\Class does not exist!
-     */
     public function test_will_not_route_unknown_class_name()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Can not route Legit\Class to some.handler.service, class Legit\Class does not exist!');
+
         $routing = new Routing(['default']);
         $routing->routeToBus('default', 'Legit\Class', 'some.handler.service');
     }
 
-    /**
-     * @expectedException        \League\Tactician\Bundle\DependencyInjection\InvalidCommandBusId
-     * @expectedExceptionMessage Could not find a command bus with id 'bus3'. Valid buses are: bus1, bus2
-     */
     public function test_will_not_accept_command_on_invalid_bus_id()
     {
+        $this->expectException(InvalidCommandBusId::class);
+        $this->expectExceptionMessage('Could not find a command bus with id \'bus3\'. Valid buses are: bus1, bus2');
+
         $routing = new Routing(['bus1', 'bus2']);
         $routing->routeToBus('bus3', FakeCommand::class, 'some.handler.service');
     }

--- a/tests/DependencyInjection/HandlerMapping/TypeHintMappingTest.php
+++ b/tests/DependencyInjection/HandlerMapping/TypeHintMappingTest.php
@@ -57,7 +57,7 @@ final class TypeHintMappingTest extends TestCase
 
     public function simpleTestCases()
     {
-        return [
+        $cases = [
             'can read __invoke magic method type hint' => [
                 InvokeHandler::class,
                 [FakeCommand::class => 'some.handler']
@@ -79,6 +79,13 @@ final class TypeHintMappingTest extends TestCase
             'will not use abstract methods' => [AbstractHandler::class, []],
             'will not use variadic methods' => [VariadicHandler::class, []]
         ];
+
+        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+            require 'php8_handlers.php';
+            $cases['will not use union type methods'] = [UnionTypeHandler::class, []];
+        }
+
+        return $cases;
     }
 
     public function test_can_bind_to_specific_bus()

--- a/tests/DependencyInjection/HandlerMapping/php8_handlers.php
+++ b/tests/DependencyInjection/HandlerMapping/php8_handlers.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace League\Tactician\Bundle\Tests\DependencyInjection\HandlerMapping;
+
+class UnionTypeHandler
+{
+    public function handle(int|bool $foo)
+    {
+    }
+}

--- a/tests/DependencyInjection/TacticianExtensionTest.php
+++ b/tests/DependencyInjection/TacticianExtensionTest.php
@@ -15,7 +15,7 @@ class TacticianExtensionTest extends AbstractExtensionTestCase
      *
      * @return ExtensionInterface[]
      */
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new TacticianExtension()

--- a/tests/Handler/ContainerBasedHandlerLocatorTest.php
+++ b/tests/Handler/ContainerBasedHandlerLocatorTest.php
@@ -3,6 +3,7 @@
 namespace League\Tactician\Bundle\Tests\Handler;
 
 use League\Tactician\Bundle\Handler\ContainerBasedHandlerLocator;
+use League\Tactician\Exception\MissingHandlerException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -22,11 +23,10 @@ class ContainerBasedHandlerLocatorTest extends TestCase
         $this->assertInstanceOf('stdClass', $locator->getHandlerForCommand('FakeCommand'));
     }
 
-    /**
-     * @expectedException \League\Tactician\Exception\MissingHandlerException
-     */
     public function testGetHandlerThrowsExceptionForNotFound()
     {
+        $this->expectException(MissingHandlerException::class);
+
         $locator = new ContainerBasedHandlerLocator(new ContainerBuilder(), [
             'OtherCommand' => 'my_bundle.order.id'
         ]);

--- a/tests/Integration/BasicCommandAndBusMappingTest.php
+++ b/tests/Integration/BasicCommandAndBusMappingTest.php
@@ -2,7 +2,10 @@
 
 namespace League\Tactician\Bundle\Tests\Integration;
 
+use League\Tactician\Bundle\DependencyInjection\InvalidCommandBusId;
+use League\Tactician\Exception\MissingHandlerException;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * @runTestsInSeparateProcesses
@@ -19,11 +22,10 @@ class BasicCommandAndBusMappingTest extends IntegrationTest
         $this->handleCommand('default', \League\Tactician\Bundle\Tests\EchoText::class, ['Hello world']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     */
     public function testHandleCommandWithInvalidMiddleware()
     {
+        $this->expectException(ServiceNotFoundException::class);
+
         $this->givenConfig('tactician', <<<'EOF'
 commandbus:
     default:
@@ -77,12 +79,11 @@ EOF
         $this->handleCommand('other', \League\Tactician\Bundle\Tests\EchoText::class, ['Welcome']);
     }
 
-    /**
-     * @expectedException \League\Tactician\Bundle\DependencyInjection\InvalidCommandBusId
-     * @expectedExceptionMessage Could not find a command bus with id 'other'. Valid buses are: default
-     */
-    public function testHandlerOnUnknownBus()
+     public function testHandlerOnUnknownBus()
     {
+        $this->expectException(InvalidCommandBusId::class);
+        $this->expectExceptionMessage('Could not find a command bus with id \'other\'. Valid buses are: default');
+
         $this->givenConfig('tactician', <<<'EOF'
 commandbus:
     default:
@@ -112,11 +113,10 @@ EOF
         static::$kernel->boot();
     }
 
-    /**
-     * @expectedException \League\Tactician\Exception\MissingHandlerException
-     */
     public function testHandleCommandSpecifiedOnAnotherBus()
     {
+        $this->expectException(MissingHandlerException::class);
+
         $this->givenConfig('tactician', <<<'EOF'
 commandbus:
     default:

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -28,7 +28,7 @@ abstract class IntegrationTest extends KernelTestCase
         return new \AppKernel('test', true);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         static::$kernel = static::createKernel();
         $this->filesystem = new Filesystem();
@@ -39,7 +39,7 @@ abstract class IntegrationTest extends KernelTestCase
         static::$kernel->defineCacheDir($cacheDir);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->filesystem->remove(
             static::$kernel->getCacheDir()

--- a/tests/Integration/MappingPrecedenceTest.php
+++ b/tests/Integration/MappingPrecedenceTest.php
@@ -10,7 +10,7 @@ use League\Tactician\Bundle\Tests\Fake\FakeCommand;
  */
 final class MappingPrecedenceTest extends IntegrationTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/SecurityTest.php
+++ b/tests/Integration/SecurityTest.php
@@ -133,7 +133,7 @@ EOF
         static::$kernel->getContainer()
             ->get('security.token_storage')
             ->setToken(
-                new AnonymousToken('test', 'anon', [new Role($role)])
+                new AnonymousToken('test', 'anon', [$role])
             );
     }
 }

--- a/tests/Middleware/SecurityMiddlewareTest.php
+++ b/tests/Middleware/SecurityMiddlewareTest.php
@@ -24,7 +24,7 @@ class SecurityMiddlewareTest extends TestCase
     /**
      * Set up.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->authorizationChecker = Mockery::mock(AuthorizationCheckerInterface::class);
     }

--- a/tests/Middleware/ValidatorMiddlewareTest.php
+++ b/tests/Middleware/ValidatorMiddlewareTest.php
@@ -22,7 +22,7 @@ class ValidatorMiddlewareTest extends TestCase
      */
     protected $middleware;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Security/Voter/HandleCommandVoterTest.php
+++ b/tests/Security/Voter/HandleCommandVoterTest.php
@@ -23,7 +23,7 @@ class HandleCommandVoterTest extends TestCase
      */
     private $decisionManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->decisionManager = Mockery::mock(AccessDecisionManager::class);
     }


### PR DESCRIPTION
And also:

- Bump minimum PHP to 7.2
- Bump PHPUnit to 8.5
- Remove unneeded Travis dependencies (although this should be probably moved to Github Actions)

fixes #124 