### PR TITLE
Also allow tactician-logger 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require" : {
     "php":  ">=7.2",
     "league/tactician": "^1.0",
-    "league/tactician-logger": "^0.10.0",
+    "league/tactician-logger": "^0.10|^0.11",
     "league/tactician-container": "^2.0",
     "symfony/config": "^3.4|^4.4|^5.0|^6.0",
     "symfony/dependency-injection": "^3.4|^4.4|^5.0|^6.0",


### PR DESCRIPTION
Below 1.0 versions work differently in composer version requirements unfortunately, so it has to be explicitly allowed

> The ^ operator behaves very similarly, but it sticks closer to semantic versioning, and will always allow non-breaking updates. For example ^1.2.3 is equivalent to >=1.2.3 <2.0.0 as none of the releases until 2.0 should break backwards compatibility. **For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0**