### PR TITLE
Add return type

### DIFF
--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -27,7 +27,7 @@ class DebugCommand extends Command
         $this->setName('debug:tactician');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
```
Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "League\Tactician\Bundle\Command\DebugCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
````