### PR TITLE
Improve support Symfony 7

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,10 +16,8 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * Create a rootnode tree for configuration that can be injected into the DI container.
-     *
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('tactician');
 


### PR DESCRIPTION
```
!!  Fatal error: Declaration of League\Tactician\Bundle\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder in /app/vendor/league/tactician-bundle/src/DependencyInjection/Configuration.php on line 22
```